### PR TITLE
fix: Activate fancy-utils tests in ci and fix UI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
       - name: Rust unit tests (mumble-protocol)
         run: cargo test --package mumble-protocol --features opus-codec --lib
 
+      - name: Rust unit tests (fancy-utils)
+        run: cargo test --package fancy-utils --lib
+
       - name: Rust unit tests (mumble-tauri)
         run: cargo test --package mumble-tauri --lib
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,7 +2684,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "mumble-protocol"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytes",
  "chacha20poly1305",

--- a/crates/mumble-protocol/Cargo.toml
+++ b/crates/mumble-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mumble-protocol"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Async Mumble protocol client library with priority-based work queue"
 license = "MIT"

--- a/crates/mumble-tauri/Cargo.toml
+++ b/crates/mumble-tauri/Cargo.toml
@@ -17,7 +17,6 @@ fancy-utils = { path = "../fancy-utils" }
 tauri = { version = "2.10.1", features = [] }
 tauri-plugin-store = "2"
 tauri-plugin-opener = "2"
-tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros", "time"] }
@@ -39,6 +38,7 @@ tauri-plugin-dialog = "2"
 mumble-protocol = { path = "../mumble-protocol", features = ["opus-codec", "persistent-chat"] }
 cpal = "0.17.3"
 tauri-plugin-global-shortcut = "2"
+tauri-plugin-window-state = "2"
 
 # Android: mumble-protocol without Opus (audio is not supported on Android).
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/mumble-tauri/tauri.conf.json
+++ b/crates/mumble-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Fancy Mumble",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.fancymumble.app",
   "build": {
     "frontendDist": "./ui/dist",

--- a/crates/mumble-tauri/ui/package-lock.json
+++ b/crates/mumble-tauri/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mumble-tauri-ui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mumble-tauri-ui",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@tauri-apps/api": "2.10.1",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/crates/mumble-tauri/ui/package.json
+++ b/crates/mumble-tauri/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mumble-tauri-ui",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/crates/mumble-tauri/ui/src/components/ChannelEditorDialog.tsx
+++ b/crates/mumble-tauri/ui/src/components/ChannelEditorDialog.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import type { ChannelEntry, PchatMode } from "../types";
 import { useAppStore } from "../store";
+import { BioEditor } from "../pages/settings/BioEditor";
 import styles from "./ChannelEditorDialog.module.css";
 
 /** Mumble permission bitmask constants. */
@@ -195,14 +196,11 @@ export default function ChannelEditorDialog({
 
         {/* Description */}
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="ch-ed-desc">Description</label>
-          <textarea
-            id="ch-ed-desc"
-            className={styles.textarea}
+          <span className={styles.label}>Description</span>
+          <BioEditor
             value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            onChange={setDescription}
             placeholder="Optional description"
-            rows={3}
           />
         </div>
 

--- a/crates/mumble-tauri/ui/src/components/ChatView.module.css
+++ b/crates/mumble-tauri/ui/src/components/ChatView.module.css
@@ -521,10 +521,7 @@
   background: transparent;
   border: none;
   border-radius: 0;
-  box-shadow:
-    0 2px 12px rgba(56, 108, 158, 0.45),
-    inset 0 1px 0 rgba(255, 255, 255, 0.22),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+  box-shadow: none;
 }
 
 .flatStyle .bubble.ownBubble:hover {


### PR DESCRIPTION
## Description

Activate fancy-utils tests in ci and fix UI issues

## Changes

- Activate fancy-utils tests in ci and fix UI issues

## Checklist

- [x] Code compiles without warnings (`cargo clippy --workspace -- -D warnings`)
- [x] TypeScript type-checks (`npx tsc --noEmit`)
- [x] Frontend tests pass (`npm test`)
- [x] Rust tests pass (`cargo test --package mumble-protocol --features opus-codec --lib`)
- [ ] New functionality has tests
- [ ] Boy Scout Rule applied - files left cleaner than found
