### PR TITLE
feat: make deepfilternet optional

### DIFF
--- a/crates/mumble-protocol/src/audio/filter/denoiser/mod.rs
+++ b/crates/mumble-protocol/src/audio/filter/denoiser/mod.rs
@@ -77,6 +77,7 @@ pub enum NoiseSuppressionAlgorithm {
     /// Provided by the [`fancy_denoiser_deepfilter`] crate.  Falls back
     /// to `Rnnoise` when the `deepfilternet-denoiser` cargo feature is
     /// not enabled.
+    #[serde(rename = "deepfilternet")]
     DeepFilterNet,
 }
 
@@ -89,6 +90,22 @@ impl NoiseSuppressionAlgorithm {
         Self::OmlsaImcra,
         Self::SpectralSubtraction,
     ];
+
+    /// Whether this algorithm has a real backend in the current build.
+    #[must_use]
+    pub fn is_available(self) -> bool {
+        match self {
+            Self::None | Self::OmlsaImcra | Self::SpectralSubtraction => true,
+            Self::Rnnoise => cfg!(feature = "rnnoise-denoiser"),
+            Self::DeepFilterNet => cfg!(feature = "deepfilternet-denoiser"),
+        }
+    }
+
+    /// Variants that actually do something in the current build.
+    #[must_use]
+    pub fn available() -> Vec<Self> {
+        Self::ALL.iter().copied().filter(|a| a.is_available()).collect()
+    }
 
     /// Human-readable label for UI display.
     pub fn label(self) -> &'static str {
@@ -315,6 +332,49 @@ mod tests {
     fn algorithm_serde_uses_snake_case() {
         let json = serde_json::to_string(&NoiseSuppressionAlgorithm::SpectralSubtraction).unwrap();
         assert_eq!(json, "\"spectral_subtraction\"");
+    }
+
+    #[test]
+    fn unconditionally_available_algorithms_are_always_listed() {
+        // `None`, `OmlsaImcra` and `SpectralSubtraction` have no
+        // optional dependencies, so they must always be reported as
+        // available regardless of which cargo features are enabled.
+        let available = NoiseSuppressionAlgorithm::available();
+        assert!(available.contains(&NoiseSuppressionAlgorithm::None));
+        assert!(available.contains(&NoiseSuppressionAlgorithm::OmlsaImcra));
+        assert!(available.contains(&NoiseSuppressionAlgorithm::SpectralSubtraction));
+        assert_eq!(NoiseSuppressionAlgorithm::None.is_available(), true);
+    }
+
+    #[test]
+    fn deepfilternet_availability_tracks_cargo_feature() {
+        let expected = cfg!(feature = "deepfilternet-denoiser");
+        assert_eq!(
+            NoiseSuppressionAlgorithm::DeepFilterNet.is_available(),
+            expected,
+            "DeepFilterNet availability must match its cargo feature flag",
+        );
+    }
+
+    #[test]
+    fn algorithm_serde_tags_match_frontend_contract() {
+        // The TypeScript `NoiseSuppressionAlgorithm` union and the
+        // persisted audio settings rely on these exact string tags.
+        // Changing them silently breaks the settings dropdown.
+        let cases = [
+            (NoiseSuppressionAlgorithm::None, "\"none\""),
+            (NoiseSuppressionAlgorithm::Rnnoise, "\"rnnoise\""),
+            (NoiseSuppressionAlgorithm::DeepFilterNet, "\"deepfilternet\""),
+            (NoiseSuppressionAlgorithm::OmlsaImcra, "\"omlsa_imcra\""),
+            (NoiseSuppressionAlgorithm::SpectralSubtraction, "\"spectral_subtraction\""),
+        ];
+        for (variant, expected) in cases {
+            let json = serde_json::to_string(&variant).expect("serialise");
+            assert_eq!(json, expected, "wire tag for {variant:?}");
+            let round: NoiseSuppressionAlgorithm =
+                serde_json::from_str(expected).expect("deserialise");
+            assert_eq!(round, variant);
+        }
     }
 
     #[test]

--- a/crates/mumble-tauri/Cargo.toml
+++ b/crates/mumble-tauri/Cargo.toml
@@ -12,6 +12,10 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 name = "mumble-tauri"
 path = "src/main.rs"
 
+[features]
+default = []
+deepfilternet-denoiser = ["mumble-protocol/deepfilternet-denoiser"]
+
 [dependencies]
 fancy-utils = { path = "../fancy-utils" }
 tauri = { version = "2.10.1", features = ["protocol-asset", "tray-icon", "image-png"] }
@@ -41,7 +45,7 @@ chrono = "0.4"
 # Desktop-only dependencies (cpal, global shortcuts, and Opus are not available on Android).
 [target.'cfg(not(target_os = "android"))'.dependencies]
 png = "0.18"
-mumble-protocol = { path = "../mumble-protocol", features = ["opus-codec", "persistent-chat", "rnnoise-denoiser", "deepfilternet-denoiser"] }
+mumble-protocol = { path = "../mumble-protocol", features = ["opus-codec", "persistent-chat", "rnnoise-denoiser"] }
 cpal = "0.17.3"
 rodio = { version = "0.22", features = ["recording"] }
 tauri-plugin-global-shortcut = "2"

--- a/crates/mumble-tauri/src/lib.rs
+++ b/crates/mumble-tauri/src/lib.rs
@@ -684,6 +684,15 @@ fn get_denoiser_param_specs(
     mumble_protocol::audio::filter::denoiser::algorithm_param_specs(algorithm).to_vec()
 }
 
+/// List the noise-suppression algorithms whose backends are actually
+/// compiled into this build.
+#[tauri::command]
+fn get_available_denoiser_algorithms()
+ -> Vec<mumble_protocol::audio::filter::denoiser::NoiseSuppressionAlgorithm>
+{
+    mumble_protocol::audio::filter::denoiser::NoiseSuppressionAlgorithm::available()
+}
+
 /// Update audio settings.
 ///
 /// If any pipeline-relevant setting changes while voice is active, the
@@ -1826,6 +1835,7 @@ macro_rules! all_command_handlers {
             get_output_devices,
             get_audio_settings,
             get_denoiser_param_specs,
+            get_available_denoiser_algorithms,
             set_audio_settings,
             set_audio_backend,
             get_audio_backend,

--- a/crates/mumble-tauri/ui/src/pages/settings/AudioPanel.tsx
+++ b/crates/mumble-tauri/ui/src/pages/settings/AudioPanel.tsx
@@ -148,6 +148,15 @@ export function AudioPanel({
   const [ampTick, setAmpTick] = useState(0);
   const rafHandle = useRef(0);
 
+  const [availableAlgorithms, setAvailableAlgorithms] = useState<
+    NoiseSuppressionAlgorithm[]
+  >(["none", "omlsa_imcra", "spectral_subtraction"]);
+  useEffect(() => {
+    invoke<NoiseSuppressionAlgorithm[]>("get_available_denoiser_algorithms")
+      .then(setAvailableAlgorithms)
+      .catch(() => { /* keep the conservative default */ });
+  }, []);
+
   const toggleMicTest = useCallback(async () => {
     if (micTestingRef.current) {
       await invoke("stop_mic_test").catch(() => {});
@@ -351,8 +360,9 @@ export function AudioPanel({
                 })
               }
             >
-              {(Object.keys(NOISE_SUPPRESSION_LABELS) as NoiseSuppressionAlgorithm[]).map(
-                (algo) => (
+              {(Object.keys(NOISE_SUPPRESSION_LABELS) as NoiseSuppressionAlgorithm[])
+                .filter((algo) => availableAlgorithms.includes(algo))
+                .map((algo) => (
                   <option key={algo} value={algo}>
                     {NOISE_SUPPRESSION_LABELS[algo]}
                   </option>


### PR DESCRIPTION
## Description

Our current implementation of [DeepFilterNet](https://github.com/Rikorose/DeepFilterNet) is only experimental and causes issues with the nix build (See #65). Therefore this PR will make it optional and default off until it is fully implemented

## Changes

Add default disabled feature `deepfilternet-denoiser`

Usage: `cargo tauri dev --features deepfilternet-denoiser`

## Checklist

- [x] Code compiles without warnings (`cargo clippy --workspace -- -D warnings`)
- [x] TypeScript type-checks (`npx tsc --noEmit`)
- [x] Frontend tests pass (`npm test`)
- [x] Rust tests pass (`cargo test --package mumble-protocol --features opus-codec --lib`)
- [x] New functionality has tests
- [x] Boy Scout Rule applied - files left cleaner than found
