### PR TITLE
Feature/multi server connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3164,7 @@ dependencies = [
 name = "mumble-tauri"
 version = "0.2.1"
 dependencies = [
+ "arc-swap",
  "base64 0.22.1",
  "cc",
  "chrono",

--- a/crates/mumble-tauri/Cargo.toml
+++ b/crates/mumble-tauri/Cargo.toml
@@ -33,6 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"] }
 rand = "0.10"
 ring = "0.17"
+arc-swap = "1"
 base64 = "0.22"
 prost = "0.14"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip", "brotli", "deflate", "multipart", "stream", "json"] }

--- a/crates/mumble-tauri/src/commands/audio.rs
+++ b/crates/mumble-tauri/src/commands/audio.rs
@@ -133,7 +133,7 @@ pub(crate) async fn set_audio_settings(
         state.restart_inbound()?;
     }
     if force_tcp_changed {
-        if let Ok(inner) = state.inner.lock() {
+        if let Ok(inner) = state.inner.snapshot().lock() {
             if let Some(ref handle) = inner.conn.client_handle {
                 handle.set_force_tcp(force_tcp);
             }

--- a/crates/mumble-tauri/src/commands/keyshare.rs
+++ b/crates/mumble-tauri/src/commands/keyshare.rs
@@ -8,7 +8,8 @@ pub(crate) fn confirm_custodians(
     state: tauri::State<'_, AppState>,
     channel_id: u32,
 ) -> Result<(), String> {
-    let mut shared = state.inner.lock().map_err(|e| e.to_string())?;
+    let __session = state.inner.snapshot();
+    let mut shared = __session.lock().map_err(|e| e.to_string())?;
     if let Some(ref mut pchat) = shared.pchat_ctx.pchat {
         pchat.key_manager.confirm_custodian_list(channel_id);
     }
@@ -21,7 +22,8 @@ pub(crate) fn accept_custodian_changes(
     state: tauri::State<'_, AppState>,
     channel_id: u32,
 ) -> Result<(), String> {
-    let mut shared = state.inner.lock().map_err(|e| e.to_string())?;
+    let __session = state.inner.snapshot();
+    let mut shared = __session.lock().map_err(|e| e.to_string())?;
     if let Some(ref mut pchat) = shared.pchat_ctx.pchat {
         pchat.key_manager.accept_custodian_update(channel_id);
     }
@@ -41,7 +43,8 @@ pub(crate) async fn approve_key_share(
 
     // Extract everything we need while holding the lock, then release it.
     let (handle, exchange, share_requests_emit) = {
-        let mut shared = state.inner.lock().map_err(|e| e.to_string())?;
+        let __session = state.inner.snapshot();
+        let mut shared = __session.lock().map_err(|e| e.to_string())?;
 
         // Remove the pending entry and capture its request_id.
         let idx = shared
@@ -122,7 +125,7 @@ pub(crate) async fn approve_key_share(
 
     // Record the peer as a key holder locally so we don't prompt consent
     // for them again on subsequent channel moves.
-    if let Ok(mut shared) = state.inner.lock() {
+    if let Ok(mut shared) = state.inner.snapshot().lock() {
         if let Some(ref mut pchat) = shared.pchat_ctx.pchat {
             pchat
                 .key_manager
@@ -151,7 +154,8 @@ pub(crate) fn dismiss_key_share(
     peer_cert_hash: String,
 ) -> Result<(), String> {
     let share_requests_emit = {
-        let mut shared = state.inner.lock().map_err(|e| e.to_string())?;
+        let __session = state.inner.snapshot();
+        let mut shared = __session.lock().map_err(|e| e.to_string())?;
 
         shared
             .pchat_ctx.pending_key_shares
@@ -191,7 +195,8 @@ pub(crate) async fn query_key_holders(
     channel_id: u32,
 ) -> Result<(), String> {
     let handle = {
-        let shared = state.inner.lock().map_err(|e| e.to_string())?;
+        let __session = state.inner.snapshot();
+        let shared = __session.lock().map_err(|e| e.to_string())?;
         shared.conn.client_handle.clone().ok_or("not connected")?
     };
     let query = mumble_protocol::proto::mumble_tcp::PchatKeyHoldersQuery {
@@ -209,7 +214,8 @@ pub(crate) fn get_key_holders(
     state: tauri::State<'_, AppState>,
     channel_id: u32,
 ) -> Vec<state::types::KeyHolderEntry> {
-    let shared = state.inner.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let __session = state.inner.snapshot();
+    let shared = __session.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     shared.pchat_ctx.key_holders.get(&channel_id).cloned().unwrap_or_default()
 }
 
@@ -232,6 +238,6 @@ pub(crate) async fn key_takeover(
         "key_only" => KeyTakeoverMode::KeyOnly,
         _ => return Err(format!("invalid takeover mode: {mode}")),
     };
-    state::pchat::send_key_takeover(&state.inner, channel_id, takeover_mode);
+    state::pchat::send_key_takeover(&state.inner.snapshot(), channel_id, takeover_mode);
     Ok(())
 }

--- a/crates/mumble-tauri/src/commands/mod.rs
+++ b/crates/mumble-tauri/src/commands/mod.rs
@@ -20,5 +20,6 @@ pub(crate) mod profile;
 pub(crate) mod public_servers;
 pub(crate) mod realtime;
 pub(crate) mod server;
+pub(crate) mod servers;
 pub(crate) mod system;
 pub(crate) mod window;

--- a/crates/mumble-tauri/src/commands/servers.rs
+++ b/crates/mumble-tauri/src/commands/servers.rs
@@ -1,0 +1,33 @@
+//! Multi-server session commands.
+
+use crate::state::{AppState, ServerId, SessionMeta};
+
+#[tauri::command]
+pub(crate) fn list_servers(state: tauri::State<'_, AppState>) -> Vec<SessionMeta> {
+    state.registry.list_meta()
+}
+
+#[tauri::command]
+pub(crate) fn get_active_server(state: tauri::State<'_, AppState>) -> Option<ServerId> {
+    state.registry.active_id()
+}
+
+#[tauri::command]
+pub(crate) async fn set_active_server(
+    state: tauri::State<'_, AppState>,
+    server_id: ServerId,
+) -> Result<(), String> {
+    state.switch_active_with_voice(server_id).await
+}
+
+/// Disconnect a specific session by id.  Operates only on that
+/// session's connection / state — does not touch the active session's
+/// `inner` pointer or its audio pipeline (unless `server_id` itself
+/// is the active session).
+#[tauri::command]
+pub(crate) async fn disconnect_server(
+    state: tauri::State<'_, AppState>,
+    server_id: ServerId,
+) -> Result<(), String> {
+    state.disconnect_session(server_id).await
+}

--- a/crates/mumble-tauri/src/commands/system.rs
+++ b/crates/mumble-tauri/src/commands/system.rs
@@ -19,7 +19,7 @@ pub(crate) fn set_notifications_enabled(
     state: tauri::State<'_, AppState>,
     enabled: bool,
 ) -> Result<(), String> {
-    state.inner.lock().map_err(|e| e.to_string())?.prefs.notifications_enabled = enabled;
+    state.inner.snapshot().lock().map_err(|e| e.to_string())?.prefs.notifications_enabled = enabled;
     Ok(())
 }
 
@@ -32,7 +32,7 @@ pub(crate) fn set_disable_dual_path(
     state: tauri::State<'_, AppState>,
     disabled: bool,
 ) -> Result<(), String> {
-    state.inner.lock().map_err(|e| e.to_string())?.prefs.disable_dual_path = disabled;
+    state.inner.snapshot().lock().map_err(|e| e.to_string())?.prefs.disable_dual_path = disabled;
     Ok(())
 }
 

--- a/crates/mumble-tauri/src/lib.rs
+++ b/crates/mumble-tauri/src/lib.rs
@@ -72,7 +72,7 @@ pub fn run() {
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::Focused(focused) = event {
                 if let Some(state) = window.try_state::<AppState>() {
-                    if let Ok(mut s) = state.inner.lock() {
+                    if let Ok(mut s) = state.inner.snapshot().lock() {
                         s.prefs.app_focused = *focused;
                     }
                 }
@@ -190,6 +190,10 @@ macro_rules! all_command_handlers {
             commands::certificates::import_certificate,
             commands::connection::disconnect,
             commands::connection::get_status,
+            commands::servers::list_servers,
+            commands::servers::get_active_server,
+            commands::servers::set_active_server,
+            commands::servers::disconnect_server,
             commands::channels::get_channels,
             commands::channels::get_users,
             commands::channels::get_user_texture,

--- a/crates/mumble-tauri/src/state/admin.rs
+++ b/crates/mumble-tauri/src/state/admin.rs
@@ -9,7 +9,8 @@ use super::AppState;
 impl AppState {
     pub async fn kick_user(&self, session: u32, reason: Option<String>) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -23,7 +24,8 @@ impl AppState {
 
     pub async fn ban_user(&self, session: u32, reason: Option<String>) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -37,7 +39,8 @@ impl AppState {
 
     pub async fn register_user(&self, session: u32) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -51,7 +54,8 @@ impl AppState {
 
     pub async fn mute_user(&self, session: u32, muted: bool) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -65,7 +69,8 @@ impl AppState {
 
     pub async fn deafen_user(&self, session: u32, deafened: bool) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -83,7 +88,8 @@ impl AppState {
         priority: bool,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -97,7 +103,8 @@ impl AppState {
 
     pub async fn reset_user_comment(&self, session: u32) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -111,7 +118,8 @@ impl AppState {
 
     pub async fn remove_user_avatar(&self, session: u32) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -125,7 +133,8 @@ impl AppState {
 
     pub async fn request_user_stats(&self, session: u32) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -139,7 +148,8 @@ impl AppState {
 
     pub async fn request_user_list(&self) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -153,7 +163,8 @@ impl AppState {
 
     pub async fn request_user_comment(&self, user_id: u32) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         let handle = handle.ok_or_else(|| "Not connected".to_owned())?;
@@ -173,7 +184,8 @@ impl AppState {
         users: Vec<RegisteredUserUpdate>,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         let entries = users
@@ -194,7 +206,8 @@ impl AppState {
 
     pub async fn request_ban_list(&self) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -230,7 +243,8 @@ impl AppState {
         let entries = entries?;
 
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -244,7 +258,8 @@ impl AppState {
 
     pub async fn request_acl(&self, channel_id: u32) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -299,7 +314,8 @@ impl AppState {
             .collect();
 
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {

--- a/crates/mumble-tauri/src/state/audio.rs
+++ b/crates/mumble-tauri/src/state/audio.rs
@@ -15,7 +15,7 @@ use super::AppState;
 impl AppState {
     /// Get current audio settings.
     pub fn audio_settings(&self) -> super::types::AudioSettings {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.audio.settings.clone())
             .unwrap_or_default()
@@ -28,7 +28,8 @@ impl AppState {
     /// Volume changes are applied live via atomic handles (no restart).
     pub fn set_audio_settings(&self, settings: super::types::AudioSettings) -> Option<(bool, bool, bool)> {
         let (old_settings, voice_active) = {
-            let state = self.inner.lock().ok()?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().ok()?;
             (
                 state.audio.settings.clone(),
                 state.audio.voice_state == VoiceState::Active,
@@ -40,7 +41,7 @@ impl AppState {
         let force_tcp_changed = old_settings.force_tcp_audio != settings.force_tcp_audio;
 
         // Update live volume handles (no pipeline restart needed).
-        if let Ok(state) = self.inner.lock() {
+        if let Ok(state) = self.inner.snapshot().lock() {
             use std::sync::atomic::Ordering;
             if let Some(ref h) = state.audio.input_volume_handle {
                 h.store(settings.input_volume.to_bits(), Ordering::Relaxed);
@@ -50,7 +51,7 @@ impl AppState {
             }
         }
 
-        if let Ok(mut state) = self.inner.lock() {
+        if let Ok(mut state) = self.inner.snapshot().lock() {
             state.audio.settings = settings;
         }
 
@@ -59,7 +60,7 @@ impl AppState {
 
     /// Get current voice state.
     pub fn voice_state(&self) -> VoiceState {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.audio.voice_state)
             .unwrap_or_default()
@@ -77,7 +78,7 @@ impl AppState {
     ///
     /// `volume` is a multiplier (0.0 = muted, 1.0 = normal, 2.0 = 200%).
     pub fn set_user_volume(&self, session: u32, volume: f32) {
-        if let Ok(state) = self.inner.lock() {
+        if let Ok(state) = self.inner.snapshot().lock() {
             if let Ok(mut sv) = state.audio.speaker_volumes.lock() {
                 if (volume - 1.0).abs() < f32::EPSILON {
                     let _ = sv.remove(&session);
@@ -119,7 +120,8 @@ mod voice_pipeline {
         /// Enable voice calling: unmute + undeaf, start audio pipelines.
         pub async fn enable_voice(&self) -> Result<(), String> {
             let (handle, audio_settings) = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 (state.conn.client_handle.clone(), state.audio.settings.clone())
             };
 
@@ -134,7 +136,8 @@ mod voice_pipeline {
                 std::sync::Mutex::new(std::collections::HashMap::new()),
             );
             let speaker_volumes = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.speaker_volumes.clone()
             };
             let mixer = AudioMixer::new(speaker_buffers.clone(), AudioFormat::MONO_48KHZ_F32);
@@ -149,7 +152,8 @@ mod voice_pipeline {
                 .map_err(|e| format!("Playback start: {e}"))?;
 
             {
-                let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let mut state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.mixer = Some(mixer);
                 state.audio.mixing_playback = Some(mixing_playback);
                 state.audio.input_volume_handle = Some(input_vol);
@@ -160,7 +164,8 @@ mod voice_pipeline {
             self.start_outbound_pipeline(&audio_settings, &handle)?;
 
             {
-                let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let mut state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.voice_state = VoiceState::Active;
             }
 
@@ -182,7 +187,8 @@ mod voice_pipeline {
             self.stop_audio();
 
             let handle = {
-                let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let mut state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.voice_state = VoiceState::Inactive;
                 state.conn.client_handle.clone()
             };
@@ -200,7 +206,18 @@ mod voice_pipeline {
 
         /// Stop all running audio pipelines and tasks.
         pub(in crate::state) fn stop_audio(&self) {
-            let stopped_sessions: Vec<(u32, tauri::AppHandle)> = if let Ok(mut state) = self.inner.lock() {
+            self.stop_audio_on(&self.inner.snapshot());
+        }
+
+        /// Stop all running audio pipelines and tasks for a specific
+        /// session arc.  Used during multi-server active-session swaps
+        /// so the previous session's pipeline can be torn down even
+        /// after `inner` has already been swapped to a new session.
+        pub(in crate::state) fn stop_audio_on(
+            &self,
+            arc: &Arc<std::sync::Mutex<crate::state::SharedState>>,
+        ) {
+            let stopped_sessions: Vec<(u32, tauri::AppHandle)> = if let Ok(mut state) = arc.lock() {
                 if let Some(handle) = state.audio.outbound_task_handle.take() {
                     handle.abort();
                 }
@@ -238,7 +255,7 @@ mod voice_pipeline {
 
         /// Stop only the outbound (mic capture) pipeline.
         fn stop_outbound(&self) {
-            if let Ok(mut state) = self.inner.lock() {
+            if let Ok(mut state) = self.inner.snapshot().lock() {
                 if let Some(handle) = state.audio.outbound_task_handle.take() {
                     handle.abort();
                 }
@@ -254,7 +271,8 @@ mod voice_pipeline {
             self.stop_outbound();
 
             let (audio_settings, client_handle) = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 (state.audio.settings.clone(), state.conn.client_handle.clone())
             };
 
@@ -268,7 +286,7 @@ mod voice_pipeline {
             info!("restart_inbound: restarting playback pipeline with new settings");
 
             // Stop the old inbound pipeline.
-            if let Ok(mut state) = self.inner.lock() {
+            if let Ok(mut state) = self.inner.snapshot().lock() {
                 if let Some(mut playback) = state.audio.mixing_playback.take() {
                     let _ = playback.stop();
                 }
@@ -276,7 +294,8 @@ mod voice_pipeline {
             }
 
             let audio_settings = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.settings.clone()
             };
 
@@ -286,7 +305,8 @@ mod voice_pipeline {
                 std::sync::Mutex::new(std::collections::HashMap::new()),
             );
             let speaker_volumes = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.speaker_volumes.clone()
             };
             let mixer = AudioMixer::new(speaker_buffers.clone(), AudioFormat::MONO_48KHZ_F32);
@@ -300,7 +320,9 @@ mod voice_pipeline {
                 .start()
                 .map_err(|e| format!("Playback start: {e}"))?;
 
-            let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+
+            let mut state = __session.lock().map_err(|e| e.to_string())?;
             state.audio.mixer = Some(mixer);
             state.audio.mixing_playback = Some(mixing_playback);
             state.audio.output_volume_handle = Some(output_vol);
@@ -315,7 +337,8 @@ mod voice_pipeline {
         ) -> Result<(), String> {
             // Re-use existing input volume handle or create a new one.
             let (input_vol, app, own_session) = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 (
                     state.audio.input_volume_handle.clone(),
                     state.conn.tauri_app_handle.clone(),
@@ -399,7 +422,9 @@ mod voice_pipeline {
                 None
             };
 
-            let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+
+            let mut state = __session.lock().map_err(|e| e.to_string())?;
             state.audio.outbound_task_handle = outbound_handle;
             state.audio.input_volume_handle = Some(input_vol);
             Ok(())
@@ -411,7 +436,8 @@ mod voice_pipeline {
         /// Used when undeafening from Inactive to land in Muted state.
         pub async fn enable_voice_muted(&self) -> Result<(), String> {
             let (handle, audio_settings) = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 (state.conn.client_handle.clone(), state.audio.settings.clone())
             };
 
@@ -423,7 +449,8 @@ mod voice_pipeline {
                 std::sync::Mutex::new(std::collections::HashMap::new()),
             );
             let speaker_volumes = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.speaker_volumes.clone()
             };
             let mixer = AudioMixer::new(speaker_buffers.clone(), AudioFormat::MONO_48KHZ_F32);
@@ -438,7 +465,8 @@ mod voice_pipeline {
                 .map_err(|e| format!("Playback start: {e}"))?;
 
             {
-                let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let mut state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.voice_state = VoiceState::Muted;
                 state.audio.mixer = Some(mixer);
                 state.audio.mixing_playback = Some(mixing_playback);
@@ -471,7 +499,8 @@ mod voice_pipeline {
         /// | Muted     | Active  |
         pub async fn toggle_mute(&self) -> Result<(), String> {
             let (voice_state, handle, audio_settings) = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 (
                     state.audio.voice_state,
                     state.conn.client_handle.clone(),
@@ -484,7 +513,8 @@ mod voice_pipeline {
                     info!("toggle_mute: muting (stopping outbound)");
                     self.stop_outbound();
                     {
-                        let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+                        let __session = self.inner.snapshot();
+                        let mut state = __session.lock().map_err(|e| e.to_string())?;
                         state.audio.voice_state = VoiceState::Muted;
                     }
                     if let Some(handle) = handle {
@@ -498,7 +528,8 @@ mod voice_pipeline {
                     info!("toggle_mute: unmuting (restarting outbound)");
                     self.start_outbound_pipeline(&audio_settings, &handle)?;
                     {
-                        let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+                        let __session = self.inner.snapshot();
+                        let mut state = __session.lock().map_err(|e| e.to_string())?;
                         state.audio.voice_state = VoiceState::Active;
                     }
                     if let Some(handle) = handle {
@@ -528,7 +559,8 @@ mod voice_pipeline {
         /// | Muted     | Inactive | (deaf + muted)
         pub async fn toggle_deafen(&self) -> Result<(), String> {
             let voice_state = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.voice_state
             };
 
@@ -553,7 +585,8 @@ mod voice_pipeline {
             self.stop_mic_test();
 
             let audio_settings = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.settings.clone()
             };
 
@@ -588,20 +621,22 @@ mod voice_pipeline {
 
             let app = self.app_handle().ok_or("No app handle")?;
             let auto_sensitivity = audio_settings.auto_input_sensitivity;
-            let inner = self.inner.clone();
+            let inner = self.inner.clone_arc();
 
             let handle = tauri::async_runtime::spawn(async move {
                 mic_test_loop(capture, app, auto_sensitivity, inner, agc_filter).await;
             });
 
-            let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+
+            let mut state = __session.lock().map_err(|e| e.to_string())?;
             state.audio.mic_test_handle = Some(handle);
             Ok(())
         }
 
         /// Stop the mic test.
         pub fn stop_mic_test(&self) {
-            if let Ok(mut state) = self.inner.lock() {
+            if let Ok(mut state) = self.inner.snapshot().lock() {
                 if let Some(handle) = state.audio.mic_test_handle.take() {
                     handle.abort();
                 }
@@ -616,7 +651,8 @@ mod voice_pipeline {
             self.stop_latency_test();
 
             let client_handle = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 state
                     .conn.client_handle
                     .clone()
@@ -627,14 +663,16 @@ mod voice_pipeline {
                 latency_ping_loop(client_handle).await;
             });
 
-            let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+
+            let mut state = __session.lock().map_err(|e| e.to_string())?;
             state.audio.latency_test_handle = Some(handle);
             Ok(())
         }
 
         /// Stop the latency test.
         pub fn stop_latency_test(&self) {
-            if let Ok(mut state) = self.inner.lock() {
+            if let Ok(mut state) = self.inner.snapshot().lock() {
                 if let Some(handle) = state.audio.latency_test_handle.take() {
                     handle.abort();
                 }
@@ -649,7 +687,8 @@ mod voice_pipeline {
         /// noise floor.  Returns the new threshold.
         pub async fn calibrate_voice_threshold(&self) -> Result<f32, String> {
             let audio_settings = {
-                let state = self.inner.lock().map_err(|e| e.to_string())?;
+                let __session = self.inner.snapshot();
+                let state = __session.lock().map_err(|e| e.to_string())?;
                 state.audio.settings.clone()
             };
 
@@ -741,7 +780,7 @@ mod voice_pipeline {
                 noise_floor_ema, threshold
             );
 
-            if let Ok(mut state) = self.inner.lock() {
+            if let Ok(mut state) = self.inner.snapshot().lock() {
                 state.audio.settings.vad_threshold = threshold;
             }
 

--- a/crates/mumble-tauri/src/state/channels.rs
+++ b/crates/mumble-tauri/src/state/channels.rs
@@ -12,7 +12,8 @@ use super::AppState;
 impl AppState {
     pub async fn select_channel(&self, channel_id: u32) -> Result<(), String> {
         let handle = {
-            let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let mut state = __session.lock().map_err(|e| e.to_string())?;
             state.selected_channel = Some(channel_id);
             state.msgs.selected_dm_user = None;
             let _ = state.msgs.channel_unread.remove(&channel_id);
@@ -31,7 +32,8 @@ impl AppState {
 
     pub async fn join_channel(&self, channel_id: u32) -> Result<(), String> {
         let handle = {
-            let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let mut state = __session.lock().map_err(|e| e.to_string())?;
             state.current_channel = Some(channel_id);
             state.conn.client_handle.clone()
         };
@@ -53,7 +55,7 @@ impl AppState {
     }
 
     pub fn current_channel(&self) -> Option<u32> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .ok()
             .and_then(|s| s.current_channel)
@@ -62,7 +64,8 @@ impl AppState {
     pub async fn toggle_listen(&self, channel_id: u32) -> Result<bool, String> {
         debug!(channel_id, "toggle_listen called");
         let (handle, is_now_listened, add, remove) = {
-            let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let mut state = __session.lock().map_err(|e| e.to_string())?;
             let handle = state.conn.client_handle.clone();
 
             if !state.permanently_listened.contains(&channel_id) {
@@ -123,7 +126,7 @@ impl AppState {
     }
 
     pub fn listened_channels(&self) -> Vec<u32> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.permanently_listened.iter().copied().collect())
             .unwrap_or_default()
@@ -143,7 +146,8 @@ impl AppState {
         pchat_retention_days: Option<u32>,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -180,7 +184,8 @@ impl AppState {
 
     pub async fn delete_channel(&self, channel_id: u32) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {
@@ -206,7 +211,8 @@ impl AppState {
         pchat_retention_days: Option<u32>,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         match handle {

--- a/crates/mumble-tauri/src/state/connection.rs
+++ b/crates/mumble-tauri/src/state/connection.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use tauri::{Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 use tracing::info;
 
 use mumble_protocol::client::ClientConfig;
@@ -11,6 +11,7 @@ use mumble_protocol::transport::tcp::TcpConfig;
 use mumble_protocol::transport::udp::UdpConfig;
 
 use super::event_handler::TauriEventHandler;
+use super::sessions::ServerId;
 use super::types::*;
 use super::{AppState, SharedState};
 
@@ -23,10 +24,28 @@ impl AppState {
         cert_label: Option<String>,
         password: Option<String>,
     ) -> Result<(), String> {
-        let inner = self.inner.clone();
         let app_handle = self.app_handle().ok_or("App not initialized")?;
 
-        reset_state_for_connect(&inner, &username, &host, port, &app_handle)?;
+        // Allocate a fresh `SharedState` for this session and register
+        // it.  Existing sessions stay alive on their own `Arc`s; we
+        // simply swap the `inner` handle to point at the new one so it
+        // becomes the active session.
+        let server_id = ServerId::new();
+        let inner = self.fresh_session_state();
+        let _ = self
+            .registry
+            .register_active(server_id, std::sync::Arc::clone(&inner));
+        let _ = self.inner.swap(std::sync::Arc::clone(&inner));
+
+        reset_state_for_connect(
+            &inner,
+            &username,
+            &host,
+            port,
+            cert_label.as_deref(),
+            server_id,
+            &app_handle,
+        )?;
         init_identity(&inner, &app_handle, &cert_label);
 
         // Emit status change so the frontend can show a loading screen immediately.
@@ -34,6 +53,8 @@ impl AppState {
 
         // Spawn the actual connection work in the background so we don't
         // block the Tauri command (which freezes the webview).
+        let registry = self.registry.clone();
+        let active_handle = self.inner.clone();
         let connect_task = tokio::spawn(async move {
             // Load client certificate from the per-identity folder.
             let (client_cert_pem, client_key_pem) = if let Some(ref label) = cert_label {
@@ -74,16 +95,29 @@ impl AppState {
                 shared: inner.clone(),
                 app: app_handle.clone(),
                 epoch,
+                server_id,
                 inbound_audio_count: 0,
             };
 
             let result = mumble_protocol::client::run(config, handler).await;
-            handle_connect_result(result, &inner, &app_handle, username, password).await;
+            handle_connect_result(
+                result,
+                ConnectResultCtx {
+                    inner: &inner,
+                    app_handle: &app_handle,
+                    username,
+                    password,
+                    registry: &registry,
+                    server_id,
+                    active_handle: &active_handle,
+                },
+            )
+            .await;
         });
 
         // Store the task handle so disconnect() can abort it if the user
         // cancels before the TCP handshake completes.
-        if let Ok(mut state) = self.inner.lock() {
+        if let Ok(mut state) = self.inner.snapshot().lock() {
             state.conn.connect_task_handle = Some(connect_task);
         }
 
@@ -91,24 +125,43 @@ impl AppState {
     }
 
     pub async fn disconnect(&self) -> Result<(), String> {
-        // Stop audio before disconnecting.
-        self.stop_audio();
+        match self.registry.active_id() {
+            Some(id) => self.disconnect_session(id).await,
+            None => Ok(()),
+        }
+    }
 
-        // Stop Android foreground service before tearing down the connection.
-        #[cfg(target_os = "android")]
-        {
-            use tauri::Manager;
-            if let Some(app_handle) = self.app_handle() {
-                if let Some(handle) =
-                    app_handle.try_state::<crate::platform::android::connection_service::ConnectionServiceHandle>()
-                {
-                    crate::platform::android::connection_service::stop_service(&handle);
+    /// Tear down a specific session by id.  When `id` is the currently
+    /// active session this also stops audio and rebinds `inner` to
+    /// whichever session becomes active next (or the empty default if
+    /// none remain).  When `id` is a non-active session the active
+    /// session's audio pipeline and `inner` pointer are left untouched.
+    pub async fn disconnect_session(&self, id: ServerId) -> Result<(), String> {
+        let arc = self
+            .registry
+            .session(id)
+            .ok_or_else(|| format!("unknown server id: {id}"))?;
+        let is_active = self.registry.active_id() == Some(id);
+
+        if is_active {
+            // Stop audio for the session being torn down (== current inner).
+            self.stop_audio_on(&arc);
+
+            // Stop Android foreground service for the active connection.
+            #[cfg(target_os = "android")]
+            {
+                if let Some(app_handle) = self.app_handle() {
+                    if let Some(handle) = app_handle
+                        .try_state::<crate::platform::android::connection_service::ConnectionServiceHandle>()
+                    {
+                        crate::platform::android::connection_service::stop_service(&handle);
+                    }
                 }
             }
         }
 
         let (handle, join, connect_task) = {
-            let mut guard = self.inner.lock().map_err(|e| e.to_string())?;
+            let mut guard = arc.lock().map_err(|e| e.to_string())?;
             guard.conn.user_initiated_disconnect = true;
             (
                 guard.conn.client_handle.take(),
@@ -141,8 +194,7 @@ impl AppState {
                 }
             }
         }
-
-        if let Ok(mut state) = self.inner.lock() {
+        if let Ok(mut state) = arc.lock() {
             // Persist signal bridge sender key state before dropping pchat.
             // Note: on_disconnected may have already cleared pchat, so this
             // is a safety net for cases where disconnect() runs first.
@@ -152,6 +204,8 @@ impl AppState {
             }
 
             state.conn.status = ConnectionStatus::Disconnected;
+            state.server_id = None;
+            state.cert_label = None;
             state.conn.client_handle = None;
             state.conn.connect_task_handle = None;
             state.conn.event_loop_handle = None;
@@ -173,6 +227,19 @@ impl AppState {
             state.pchat_ctx.pending_key_shares.clear();
         }
 
+        // Drop the session from the registry so `list_servers` reflects
+        // the disconnect.  If this was the active session, also rebind
+        // `inner` to whichever session (if any) becomes active next.
+        let _ = self.registry.remove(id);
+        if is_active {
+            match self.registry.active_id().and_then(|nid| self.registry.session(nid)) {
+                Some(next_arc) => {
+                    let _ = self.inner.swap(next_arc);
+                }
+                None => self.reset_to_default(),
+            }
+        }
+
         Ok(())
     }
 }
@@ -190,7 +257,9 @@ fn reset_state_for_connect(
     username: &str,
     host: &str,
     port: u16,
-    app_handle: &tauri::AppHandle,
+    cert_label: Option<&str>,
+    server_id: ServerId,
+    app_handle: &AppHandle,
 ) -> Result<(), String> {
     let mut state = inner.lock().map_err(|e| e.to_string())?;
 
@@ -205,6 +274,8 @@ fn reset_state_for_connect(
     }
 
     state.conn.epoch += 1;
+    state.server_id = Some(server_id);
+    state.cert_label = cert_label.map(str::to_owned);
     state.conn.status = ConnectionStatus::Connecting;
     state.conn.own_name = username.to_owned();
     state.server.host = host.to_owned();
@@ -240,7 +311,7 @@ fn reset_state_for_connect(
 /// the identity seed for the given certificate label.
 fn init_identity(
     inner: &SharedInner,
-    app_handle: &tauri::AppHandle,
+    app_handle: &AppHandle,
     cert_label: &Option<String>,
 ) {
     // Cert-hash-to-username resolver (persisted across sessions).
@@ -276,6 +347,18 @@ fn init_identity(
     }
 }
 
+/// Bundle of context passed to [`handle_connect_result`] so the
+/// function signature stays within Clippy's `too_many_arguments` limit.
+struct ConnectResultCtx<'a> {
+    inner: &'a SharedInner,
+    app_handle: &'a AppHandle,
+    username: String,
+    password: Option<String>,
+    registry: &'a super::registry::Registry,
+    server_id: ServerId,
+    active_handle: &'a super::shared_handle::SharedHandle,
+}
+
 /// Handle the result of `mumble_protocol::client::run()`: store handles,
 /// send Authenticate, or emit rejection events on failure.
 async fn handle_connect_result(
@@ -283,11 +366,17 @@ async fn handle_connect_result(
         (mumble_protocol::client::ClientHandle, tokio::task::JoinHandle<()>),
         mumble_protocol::error::Error,
     >,
-    inner: &SharedInner,
-    app_handle: &tauri::AppHandle,
-    username: String,
-    password: Option<String>,
+    ctx: ConnectResultCtx<'_>,
 ) {
+    let ConnectResultCtx {
+        inner,
+        app_handle,
+        username,
+        password,
+        registry,
+        server_id,
+        active_handle,
+    } = ctx;
     match result {
         Ok((handle, join)) => {
             if let Ok(mut state) = inner.lock() {
@@ -307,13 +396,10 @@ async fn handle_connect_result(
             {
                 tracing::error!("Failed to send auth: {e}");
                 mark_disconnected(inner);
-                let _ = app_handle.emit(
-                    "connection-rejected",
-                    RejectedPayload {
-                        reason: format!("Failed to authenticate: {e}"),
-                        reject_type: None,
-                    },
-                );
+                let _ = registry.remove(server_id);
+                rebind_active(active_handle, registry);
+                let reason = format!("Failed to authenticate: {e}");
+                emit_session_rejected(app_handle, server_id, reason);
                 return;
             }
 
@@ -331,23 +417,56 @@ async fn handle_connect_result(
         Err(e) => {
             tracing::error!("Connection failed: {e}");
             mark_disconnected(inner);
-            let _ = app_handle.emit(
-                "connection-rejected",
-                RejectedPayload {
-                    reason: format!("Connection failed: {e}"),
-                    reject_type: None,
-                },
-            );
+            let _ = registry.remove(server_id);
+            rebind_active(active_handle, registry);
+            let reason = format!("Connection failed: {e}");
+            emit_session_rejected(app_handle, server_id, reason);
         }
     }
+}
+
+/// Emit `connection-rejected` (and matching `server-disconnected`) for
+/// a specific session id, ensuring the frontend can route the events
+/// to the correct tab without affecting other sessions.
+fn emit_session_rejected(app_handle: &AppHandle, server_id: ServerId, reason: String) {
+    let id = server_id.to_string();
+    let _ = app_handle.emit(
+        "connection-rejected",
+        serde_json::json!({
+            "serverId": id.clone(),
+            "reason": reason.clone(),
+            "reject_type": serde_json::Value::Null,
+        }),
+    );
+    let _ = app_handle.emit(
+        "server-disconnected",
+        DisconnectedPayload { server_id: Some(id), reason: Some(reason) },
+    );
 }
 
 /// Clear connection handles and set status to `Disconnected`.
 fn mark_disconnected(inner: &SharedInner) {
     if let Ok(mut state) = inner.lock() {
         state.conn.status = ConnectionStatus::Disconnected;
+        state.server_id = None;
+        state.cert_label = None;
         state.conn.client_handle = None;
         state.conn.event_loop_handle = None;
         state.conn.connect_task_handle = None;
+    }
+}
+
+/// After a session is removed from the registry, point `active_handle`
+/// at whichever session became active next (or leave it pointing at the
+/// failed session if nothing remains; callers may also explicitly reset).
+fn rebind_active(
+    active_handle: &super::shared_handle::SharedHandle,
+    registry: &super::registry::Registry,
+) {
+    if let Some(arc) = registry
+        .active_id()
+        .and_then(|id| registry.session(id))
+    {
+        let _ = active_handle.swap(arc);
     }
 }

--- a/crates/mumble-tauri/src/state/event_handler.rs
+++ b/crates/mumble-tauri/src/state/event_handler.rs
@@ -23,12 +23,32 @@ use super::types::*;
 use super::SharedState;
 
 /// Tauri-backed event emitter forwarding to `AppHandle::emit`.
+///
+/// Stamps every JSON object payload with a `serverId` field identifying
+/// the active session at emit time so the frontend can route events to
+/// the correct server tab.  Non-object payloads (strings, arrays) are
+/// forwarded unchanged.
 struct TauriEmitter {
     app: AppHandle,
+    shared: Arc<Mutex<SharedState>>,
+}
+
+impl TauriEmitter {
+    fn active_server_id(&self) -> Option<String> {
+        self.shared
+            .lock()
+            .ok()
+            .and_then(|g| g.server_id.map(|id| id.to_string()))
+    }
 }
 
 impl EventEmitter for TauriEmitter {
-    fn emit_json(&self, event: &str, payload: serde_json::Value) {
+    fn emit_json(&self, event: &str, mut payload: serde_json::Value) {
+        if let (Some(id), Some(obj)) = (self.active_server_id(), payload.as_object_mut()) {
+            let _ = obj
+                .entry("serverId")
+                .or_insert(serde_json::Value::String(id));
+        }
         let _ = self.app.emit(event, payload);
     }
 
@@ -94,6 +114,11 @@ pub(super) struct TauriEventHandler {
     /// `on_disconnected` only acts when this matches the current epoch,
     /// preventing stale callbacks from orphaned tasks.
     pub epoch: u64,
+    /// The session id this handler was created for.  Used by
+    /// `on_disconnected` to emit a correctly-scoped
+    /// `DisconnectedPayload` even after `disconnect_session` has
+    /// already cleared `state.server_id` as part of its teardown.
+    pub server_id: super::sessions::ServerId,
     /// Running count of inbound audio packets (for periodic diagnostics).
     pub(super) inbound_audio_count: u64,
 }
@@ -104,6 +129,7 @@ impl EventHandler for TauriEventHandler {
             shared: Arc::clone(&self.shared),
             emitter: Box::new(TauriEmitter {
                 app: self.app.clone(),
+                shared: Arc::clone(&self.shared),
             }),
         };
         handler::dispatch(msg, &ctx);
@@ -191,6 +217,8 @@ impl EventHandler for TauriEventHandler {
             }
 
             state.conn.status = ConnectionStatus::Disconnected;
+            state.server_id = None;
+            state.cert_label = None;
             state.conn.client_handle = None;
             state.conn.event_loop_handle = None;
             // Stop audio pipelines on disconnect.
@@ -221,8 +249,15 @@ impl EventHandler for TauriEventHandler {
             user_initiated = state.conn.user_initiated_disconnect;
             state.conn.user_initiated_disconnect = false;
         }
-        let reason = if user_initiated { None } else { Some("Connection to server was lost.") };
-        let _ = self.app.emit("server-disconnected", reason);
+        let reason = if user_initiated {
+            None
+        } else {
+            Some("Connection to server was lost.".to_string())
+        };
+        let _ = self.app.emit(
+            "server-disconnected",
+            DisconnectedPayload { server_id: Some(self.server_id.to_string()), reason },
+        );
 
         // Stop Android foreground service now that we are disconnected.
         #[cfg(target_os = "android")]

--- a/crates/mumble-tauri/src/state/handler/user_remove.rs
+++ b/crates/mumble-tauri/src/state/handler/user_remove.rs
@@ -22,6 +22,12 @@ impl HandleMessage for mumble_tcp::UserRemove {
                 state.conn.status = ConnectionStatus::Disconnected;
                 state.conn.client_handle = None;
                 state.conn.event_loop_handle = None;
+                // Mark this disconnect as user-initiated from the protocol
+                // layer's point of view: the upcoming `on_disconnected`
+                // callback (triggered when the TCP connection drops) must
+                // NOT emit its own generic "Connection to server was lost."
+                // reason that would clobber the kick reason we emit below.
+                state.conn.user_initiated_disconnect = true;
                 state.users.clear();
                 state.channels.clear();
                 state.msgs.by_channel.clear();
@@ -42,8 +48,14 @@ impl HandleMessage for mumble_tcp::UserRemove {
                 #[cfg(not(target_os = "android"))]
                 stop_audio_pipelines(&mut state);
             }
-            ctx.emit("connection-rejected", RejectedPayload { reason, reject_type: None });
-            ctx.emit_empty("server-disconnected");
+            ctx.emit("connection-rejected", RejectedPayload { reason: reason.clone(), reject_type: None });
+            // server_id stays set on shared state until the connect helper
+            // tears the session down; the TauriEmitter will stamp `serverId`
+            // onto the object payload so the frontend can route the event.
+            ctx.emit(
+                "server-disconnected",
+                DisconnectedPayload { server_id: None, reason: Some(reason) },
+            );
         } else {
             // Look up the departing user's name for the activity log.
             let departing_name = ctx

--- a/crates/mumble-tauri/src/state/messaging/dm.rs
+++ b/crates/mumble-tauri/src/state/messaging/dm.rs
@@ -9,7 +9,8 @@ use crate::state::AppState;
 impl AppState {
     pub async fn send_dm(&self, target_session: u32, body: String) -> Result<(), String> {
         let (handle, own_session, own_name, own_hash, is_fancy) = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             let hash = own_session_hash(&state);
             (
                 state.conn.client_handle.clone(),
@@ -46,7 +47,7 @@ impl AppState {
             .await
             .map_err(|e| format!("Failed to send DM: {e}"))?;
 
-        if let Ok(mut state) = self.inner.lock() {
+        if let Ok(mut state) = self.inner.snapshot().lock() {
             let mut msg = ChatMessage {
                 sender_session: own_session,
                 sender_name: own_name,
@@ -73,7 +74,8 @@ impl AppState {
 
     pub fn select_dm_user(&self, session: u32) -> Result<(), String> {
         {
-            let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let mut state = __session.lock().map_err(|e| e.to_string())?;
             state.msgs.selected_dm_user = Some(session);
             state.selected_channel = None;
             let _ = state.msgs.dm_unread.remove(&session);

--- a/crates/mumble-tauri/src/state/messaging/mod.rs
+++ b/crates/mumble-tauri/src/state/messaging/mod.rs
@@ -55,7 +55,8 @@ impl AppState {
         limit: u32,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
         let handle = handle.ok_or("Not connected")?;
@@ -64,7 +65,8 @@ impl AppState {
 
     pub async fn send_message(&self, channel_id: u32, body: String) -> Result<(), String> {
         let (handle, own_session, own_name, own_hash, is_fancy, pchat_protocol) = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             let pchat_proto = state
                 .channels
                 .get(&channel_id)
@@ -93,6 +95,7 @@ impl AppState {
             .is_some_and(|p| p.is_encrypted())
             && self
                 .inner
+                .snapshot()
                 .lock()
                 .map(|s| s.prefs.disable_dual_path)
                 .unwrap_or(false);
@@ -150,7 +153,8 @@ impl AppState {
         let Some(ref msg_id) = message_id else {
             return Ok(None);
         };
-        let session = self.inner.lock().ok()
+        let __session = self.inner.snapshot();
+        let session = __session.lock().ok()
             .and_then(|s| s.conn.own_session)
             .unwrap_or(0);
         self.build_pchat_encrypted(&pchat::OutboundMessage {
@@ -165,7 +169,8 @@ impl AppState {
     }
 
     fn store_own_message(&self, msg_data: OwnMessageData) {
-        let Ok(mut state) = self.inner.lock() else { return };
+        let __session = self.inner.snapshot();
+        let Ok(mut state) = __session.lock() else { return };
         let mut msg = ChatMessage {
             sender_session: msg_data.own_session,
             sender_name: msg_data.own_name,
@@ -199,7 +204,8 @@ impl AppState {
         new_body: String,
     ) -> Result<(), String> {
         let (handle, is_fancy) = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             (
                 state.conn.client_handle.clone(),
                 state.server.fancy_version.is_some(),
@@ -229,7 +235,7 @@ impl AppState {
             .await
             .map_err(|e| format!("Failed to send edit: {e}"))?;
 
-        if let Ok(mut state) = self.inner.lock() {
+        if let Ok(mut state) = self.inner.snapshot().lock() {
             if let Some(msgs) = state.msgs.by_channel.get_mut(&channel_id) {
                 if let Some(msg) = msgs.iter_mut().find(|m| m.message_id.as_deref() == Some(&message_id)) {
                     msg.body = new_body;
@@ -246,7 +252,8 @@ impl AppState {
         &self,
         outbound: &pchat::OutboundMessage<'_>,
     ) -> Result<Option<(mumble_protocol::proto::mumble_tcp::PchatMessage, ClientHandle)>, String> {
-        let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+        let __session = self.inner.snapshot();
+        let mut state = __session.lock().map_err(|e| e.to_string())?;
         let client = state.conn.client_handle.clone();
         if let (Some(ref mut pchat_state), Some(client)) = (&mut state.pchat_ctx.pchat, client) {
             if outbound.protocol == PchatProtocol::SignalV1

--- a/crates/mumble-tauri/src/state/messaging/unreads.rs
+++ b/crates/mumble-tauri/src/state/messaging/unreads.rs
@@ -9,14 +9,14 @@ use crate::state::AppState;
 
 impl AppState {
     pub fn unread_counts(&self) -> HashMap<u32, u32> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.msgs.channel_unread.clone())
             .unwrap_or_default()
     }
 
     pub fn mark_read(&self, channel_id: u32) {
-        if let Ok(mut state) = self.inner.lock() {
+        if let Ok(mut state) = self.inner.snapshot().lock() {
             let _ = state.msgs.channel_unread.remove(&channel_id);
         }
         self.emit_unreads();
@@ -30,14 +30,14 @@ impl AppState {
     }
 
     pub fn dm_unread_counts(&self) -> HashMap<u32, u32> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.msgs.dm_unread.clone())
             .unwrap_or_default()
     }
 
     pub fn mark_dm_read(&self, session: u32) {
-        if let Ok(mut state) = self.inner.lock() {
+        if let Ok(mut state) = self.inner.snapshot().lock() {
             let _ = state.msgs.dm_unread.remove(&session);
         }
         self.emit_dm_unreads();

--- a/crates/mumble-tauri/src/state/mod.rs
+++ b/crates/mumble-tauri/src/state/mod.rs
@@ -36,10 +36,14 @@ mod protocol_commands;
 mod query;
 #[allow(dead_code, reason = "recording module is work-in-progress")]
 pub(crate) mod recording;
+mod registry;
 mod search;
+mod sessions;
+mod shared_handle;
 pub mod types;
 
 // Re-export everything that lib.rs needs.
+pub use sessions::{ServerId, SessionMeta};
 pub use types::{
     AudioDevice, AudioSettings, ChannelEntry, ChatMessage, ConnectionStatus, DebugStats,
     PhotoEntry, SearchResult, ServerConfig, ServerInfo, UserEntry, VoiceState,
@@ -106,7 +110,7 @@ pub(super) struct ServerMetadata {
 }
 
 /// User-level preference flags.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(super) struct AppPreferences {
     pub notifications_enabled: bool,
     pub disable_dual_path: bool,
@@ -184,13 +188,32 @@ pub(super) struct SharedState {
     pub pchat_ctx: PchatContext,
     pub prefs: AppPreferences,
     pub offload_store: Option<OffloadStore>,
+    /// Multi-server: stable id of the connection this state belongs to.
+    /// Set when the session is registered, cleared on teardown.
+    pub server_id: Option<ServerId>,
+    /// Certificate label used for this connection (if any), kept so
+    /// `list_servers` can surface it without re-querying the connect args.
+    pub cert_label: Option<String>,
 }
 
 // --- Tauri-managed application state ------------------------------
 
 /// Central state managed by Tauri and shared across all commands.
 pub struct AppState {
-    pub(crate) inner: Arc<Mutex<SharedState>>,
+    /// Atomically-swappable handle to the currently-active session's
+    /// [`SharedState`].  Existing call sites continue to spell
+    /// `state.inner.snapshot().lock()`; under the hood the lock targets whichever
+    /// session is active at lock time.
+    pub(crate) inner: shared_handle::SharedHandle,
+    /// Multi-server registry mapping `ServerId -> Arc<Mutex<SharedState>>`,
+    /// plus which session is currently active.  Each connected server
+    /// has its own backing `SharedState` so per-server data (channels,
+    /// users, messages, audio) stays isolated.
+    pub(crate) registry: registry::Registry,
+    /// Default empty `SharedState` selected when no server is connected,
+    /// so commands can always lock something and observe a sensible
+    /// disconnected view instead of failing.
+    default_inner: Arc<Mutex<SharedState>>,
     app_handle: Mutex<Option<AppHandle>>,
     start_time: Instant,
     http_client: reqwest::Client,
@@ -202,21 +225,113 @@ pub struct AppState {
 
 impl AppState {
     pub fn new() -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(SharedState {
-                prefs: AppPreferences {
-                    notifications_enabled: true,
-                    app_focused: true,
-                    ..Default::default()
-                },
+        let default_inner = Arc::new(Mutex::new(SharedState {
+            prefs: AppPreferences {
+                notifications_enabled: true,
+                app_focused: true,
                 ..Default::default()
-            })),
+            },
+            ..Default::default()
+        }));
+        Self {
+            registry: registry::Registry::default(),
+            inner: shared_handle::SharedHandle::new(Arc::clone(&default_inner)),
+            default_inner,
             app_handle: Mutex::new(None),
             start_time: Instant::now(),
             http_client: file_server::new_http_client(),
             upload_cancels: Mutex::new(HashMap::new()),
             popout_images: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Build a fresh, empty per-session `SharedState` with the same
+    /// global preferences as the default one (notifications on, focused).
+    pub(crate) fn fresh_session_state(&self) -> Arc<Mutex<SharedState>> {
+        let prefs = self
+            .default_inner
+            .lock()
+            .map(|s| s.prefs.clone())
+            .unwrap_or_default();
+        Arc::new(Mutex::new(SharedState {
+            prefs,
+            ..Default::default()
+        }))
+    }
+
+    /// Switch the currently-active session to `target`.  Updates both
+    /// the registry's `active` pointer and the `inner` swap so commands
+    /// without an explicit `serverId` start operating on the new session.
+    pub(crate) fn switch_active_to(&self, target: ServerId) -> Result<(), String> {
+        let arc = self
+            .registry
+            .session(target)
+            .ok_or_else(|| format!("unknown server id: {target}"))?;
+        self.registry.set_active(target)?;
+        let _ = self.inner.swap(arc);
+        Ok(())
+    }
+
+    /// Switch the active session to `target` and migrate any running
+    /// voice pipeline along with it.  If voice was Active or Muted on
+    /// the previously-active session, it is stopped there and started
+    /// on the new active session in the same mode.  Voice always
+    /// follows the active server.
+    pub(crate) async fn switch_active_with_voice(
+        &self,
+        target: ServerId,
+    ) -> Result<(), String> {
+        use crate::state::types::VoiceState;
+
+        let prev_arc = self.inner.snapshot();
+        let target_arc = self
+            .registry
+            .session(target)
+            .ok_or_else(|| format!("unknown server id: {target}"))?;
+
+        if Arc::ptr_eq(&prev_arc, &target_arc) {
+            return Ok(());
+        }
+        drop(target_arc);
+
+        let prev_voice = prev_arc
+            .lock()
+            .map(|s| s.audio.voice_state)
+            .unwrap_or_default();
+
+        if prev_voice != VoiceState::Inactive {
+            self.stop_audio_on(&prev_arc);
+            if let Ok(mut s) = prev_arc.lock() {
+                s.audio.voice_state = VoiceState::Inactive;
+            }
+        }
+
+        self.switch_active_to(target)?;
+
+        match prev_voice {
+            VoiceState::Inactive => {}
+            VoiceState::Active => {
+                if let Err(e) = self.enable_voice().await {
+                    tracing::warn!("voice migration: enable_voice on new active failed: {e}");
+                }
+            }
+            VoiceState::Muted => {
+                if let Err(e) = self.enable_voice_muted().await {
+                    tracing::warn!(
+                        "voice migration: enable_voice_muted on new active failed: {e}"
+                    );
+                }
+            }
+        }
+
+        self.emit_voice_state();
+        Ok(())
+    }
+
+    /// Reset `inner` to the empty default `SharedState` (used when the
+    /// last session disconnects).
+    pub(crate) fn reset_to_default(&self) {
+        let _ = self.inner.swap(Arc::clone(&self.default_inner));
     }
 
     /// Inject the Tauri `AppHandle` during setup.
@@ -254,6 +369,11 @@ impl AppState {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "panic-on-failure is acceptable in test code"
+)]
 mod tests {
     use super::*;
 
@@ -299,5 +419,114 @@ mod tests {
         }
         assert_eq!(buf.len(), 10);
         assert_eq!(buf.first().and_then(|m| m.timestamp), Some(0));
+    }
+
+    // Phase E: voice migration on active-session switch.
+    //
+    // We cover the safe branches that don't try to start a real audio
+    // pipeline: unknown target, same-as-active no-op, and the
+    // VoiceState::Inactive case where migration just performs the swap.
+
+    fn register_idle_session(state: &AppState) -> ServerId {
+        let id = ServerId::new();
+        let arc = state.fresh_session_state();
+        let _ = state.registry.register_active(id, arc);
+        id
+    }
+
+
+    #[tokio::test]
+    async fn switch_active_with_voice_unknown_target_errors() {
+        let state = AppState::new();
+        let _ = register_idle_session(&state);
+        let bogus = ServerId::new();
+        assert!(state.switch_active_with_voice(bogus).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn switch_active_with_voice_same_session_is_noop() {
+        let state = AppState::new();
+        let id = register_idle_session(&state);
+        // Point `inner` at the registered session (registration alone
+        // only updates the registry).
+        state.switch_active_to(id).expect("ok");
+        let prev = state.inner.snapshot();
+        state.switch_active_with_voice(id).await.expect("ok");
+        let next = state.inner.snapshot();
+        assert!(Arc::ptr_eq(&prev, &next));
+    }
+
+    #[tokio::test]
+    async fn switch_active_with_voice_inactive_just_swaps() {
+        let state = AppState::new();
+        let a = register_idle_session(&state);
+        let b = register_idle_session(&state);
+        // Most recently registered wins active in the registry.
+        assert_eq!(state.registry.active_id(), Some(b));
+        state.switch_active_to(b).expect("ok");
+        state.switch_active_with_voice(a).await.expect("ok");
+        assert_eq!(state.registry.active_id(), Some(a));
+        let active_arc = state.registry.session(a).expect("a present");
+        assert!(Arc::ptr_eq(&state.inner.snapshot(), &active_arc));
+    }
+
+    // Regression: disconnecting a non-active session must NOT touch
+    // the active session's `inner` pointer, the active session's
+    // SharedState, or the active session's audio pipeline.
+
+    #[tokio::test]
+    async fn disconnect_session_non_active_leaves_active_inner_intact() {
+        let state = AppState::new();
+        let active = register_idle_session(&state);
+        let victim = register_idle_session(&state);
+        state.switch_active_to(active).expect("ok");
+
+        let active_arc_before = state.registry.session(active).expect("active");
+        assert!(Arc::ptr_eq(&state.inner.snapshot(), &active_arc_before));
+
+        state.disconnect_session(victim).await.expect("ok");
+
+        // Victim removed from registry.
+        assert!(state.registry.session(victim).is_none());
+        // Active still active and `inner` still points at it.
+        assert_eq!(state.registry.active_id(), Some(active));
+        assert!(Arc::ptr_eq(&state.inner.snapshot(), &active_arc_before));
+    }
+
+    #[tokio::test]
+    async fn disconnect_session_active_rebinds_inner_to_remaining() {
+        let state = AppState::new();
+        let other = register_idle_session(&state);
+        let active = register_idle_session(&state);
+        state.switch_active_to(active).expect("ok");
+
+        state.disconnect_session(active).await.expect("ok");
+
+        // Active gone, the remaining session takes over.
+        assert!(state.registry.session(active).is_none());
+        assert_eq!(state.registry.active_id(), Some(other));
+        let other_arc = state.registry.session(other).expect("other present");
+        assert!(Arc::ptr_eq(&state.inner.snapshot(), &other_arc));
+    }
+
+    #[tokio::test]
+    async fn disconnect_session_last_resets_to_default() {
+        let state = AppState::new();
+        let only = register_idle_session(&state);
+        state.switch_active_to(only).expect("ok");
+
+        state.disconnect_session(only).await.expect("ok");
+
+        assert!(state.registry.active_id().is_none());
+        // `inner` must point at the empty default state.
+        assert!(Arc::ptr_eq(&state.inner.snapshot(), &state.default_inner));
+    }
+
+    #[tokio::test]
+    async fn disconnect_session_unknown_id_errors() {
+        let state = AppState::new();
+        let _active = register_idle_session(&state);
+        let bogus = ServerId::new();
+        assert!(state.disconnect_session(bogus).await.is_err());
     }
 }

--- a/crates/mumble-tauri/src/state/offload_ops.rs
+++ b/crates/mumble-tauri/src/state/offload_ops.rs
@@ -13,7 +13,7 @@ impl AppState {
         let base_dir = self.offload_base_dir()?;
         OffloadStore::cleanup_stale(&base_dir);
         let store = OffloadStore::new(base_dir)?;
-        if let Ok(mut state) = self.inner.lock() {
+        if let Ok(mut state) = self.inner.snapshot().lock() {
             state.offload_store = Some(store);
         }
         Ok(())
@@ -34,7 +34,8 @@ impl AppState {
         scope: String,
         scope_id: String,
     ) -> Result<(), String> {
-        let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+        let __session = self.inner.snapshot();
+        let mut state = __session.lock().map_err(|e| e.to_string())?;
 
         let body = find_message_body(&state, &scope, &scope_id, &message_id)?;
 
@@ -67,7 +68,8 @@ impl AppState {
         scope: String,
         scope_id: String,
     ) -> Result<String, String> {
-        let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+        let __session = self.inner.snapshot();
+        let mut state = __session.lock().map_err(|e| e.to_string())?;
 
         let store = state
             .offload_store
@@ -87,7 +89,8 @@ impl AppState {
         scope: String,
         scope_id: String,
     ) -> Result<HashMap<String, String>, String> {
-        let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+        let __session = self.inner.snapshot();
+        let mut state = __session.lock().map_err(|e| e.to_string())?;
 
         let store = state
             .offload_store
@@ -113,7 +116,7 @@ impl AppState {
     }
 
     pub fn clear_offloaded(&self) {
-        if let Ok(mut state) = self.inner.lock() {
+        if let Ok(mut state) = self.inner.snapshot().lock() {
             if let Some(store) = state.offload_store.as_mut() {
                 store.clear();
             }
@@ -121,7 +124,7 @@ impl AppState {
     }
 
     pub fn shutdown_offload_store(&self) {
-        if let Ok(mut state) = self.inner.lock() {
+        if let Ok(mut state) = self.inner.snapshot().lock() {
             if let Some(store) = state.offload_store.as_mut() {
                 store.cleanup_dir();
             }

--- a/crates/mumble-tauri/src/state/profile.rs
+++ b/crates/mumble-tauri/src/state/profile.rs
@@ -9,7 +9,8 @@ impl AppState {
     /// Set the user's comment on the connected server.
     pub async fn set_user_comment(&self, comment: String) -> Result<(), String> {
         let (handle, own_session) = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             (state.conn.client_handle.clone(), state.conn.own_session)
         };
         match handle {
@@ -21,7 +22,8 @@ impl AppState {
                 .map_err(|e| e.to_string())?;
 
                 if let Some(session) = own_session {
-                    let _ = self.inner.lock().ok().and_then(|mut state| {
+                    let __session = self.inner.snapshot();
+                    let _ = __session.lock().ok().and_then(|mut state| {
                         let user = state.users.get_mut(&session)?;
                         user.comment = (!comment.is_empty()).then_some(comment);
                         Some(())
@@ -39,7 +41,8 @@ impl AppState {
     /// Set the user's avatar texture on the connected server.
     pub async fn set_user_texture(&self, texture: Vec<u8>) -> Result<(), String> {
         let (handle, own_session) = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             (state.conn.client_handle.clone(), state.conn.own_session)
         };
         match handle {
@@ -51,7 +54,8 @@ impl AppState {
                 .map_err(|e| e.to_string())?;
 
                 if let Some(session) = own_session {
-                    let _ = self.inner.lock().ok().and_then(|mut state| {
+                    let __session = self.inner.snapshot();
+                    let _ = __session.lock().ok().and_then(|mut state| {
                         let user = state.users.get_mut(&session)?;
                         user.texture = (!texture.is_empty()).then_some(texture);
                         Some(())

--- a/crates/mumble-tauri/src/state/protocol_commands.rs
+++ b/crates/mumble-tauri/src/state/protocol_commands.rs
@@ -15,7 +15,8 @@ impl AppState {
         data_id: String,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
 
@@ -35,7 +36,8 @@ impl AppState {
 
     pub async fn send_push_update(&self, muted_channels: Vec<u32>) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
 
@@ -63,7 +65,8 @@ impl AppState {
         muted_channels: Vec<u32>,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
 
@@ -79,7 +82,8 @@ impl AppState {
 
     pub async fn send_typing_indicator(&self, channel_id: u32) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
 
@@ -99,7 +103,8 @@ impl AppState {
         request_id: String,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
 
@@ -119,7 +124,8 @@ impl AppState {
         last_read_message_id: String,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
 
@@ -140,7 +146,8 @@ impl AppState {
 
     pub async fn query_read_receipts(&self, channel_id: u32) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
 
@@ -166,7 +173,8 @@ impl AppState {
         payload: String,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
 
@@ -192,7 +200,8 @@ impl AppState {
         action: String,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
 
@@ -246,7 +255,8 @@ impl AppState {
         unpin: bool,
     ) -> Result<(), String> {
         let handle = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             state.conn.client_handle.clone()
         };
 
@@ -277,7 +287,8 @@ impl AppState {
         sender_hash: Option<String>,
     ) -> Result<(), String> {
         let (handle, rx) = {
-            let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let mut state = __session.lock().map_err(|e| e.to_string())?;
             let h = state.conn.client_handle.clone().ok_or("Not connected")?;
 
             let (tx, rx) = tokio::sync::oneshot::channel::<DeleteAckResult>();

--- a/crates/mumble-tauri/src/state/query.rs
+++ b/crates/mumble-tauri/src/state/query.rs
@@ -7,14 +7,14 @@ use super::AppState;
 
 impl AppState {
     pub fn status(&self) -> ConnectionStatus {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.conn.status)
             .unwrap_or(ConnectionStatus::Disconnected)
     }
 
     pub fn channels(&self) -> Vec<ChannelEntry> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|mut s| {
                 Self::refresh_user_counts(&mut s);
@@ -32,7 +32,7 @@ impl AppState {
     }
 
     pub fn users(&self) -> Vec<UserEntry> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.users.values().cloned().collect())
             .unwrap_or_default()
@@ -43,7 +43,7 @@ impl AppState {
     /// lazily fetch avatars after `get_users` returned only the byte
     /// length (`texture_size`).
     pub fn user_texture(&self, session: u32) -> Option<Vec<u8>> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .ok()
             .and_then(|s| s.users.get(&session).and_then(|u| u.texture.clone()))
@@ -54,7 +54,7 @@ impl AppState {
     /// lazily fetch descriptions after `get_channels` returned only the
     /// byte length (`description_size`).
     pub fn channel_description(&self, channel_id: u32) -> Option<String> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .ok()
             .and_then(|s| s.channels.get(&channel_id).map(|c| c.description.clone()))
@@ -62,39 +62,39 @@ impl AppState {
     }
 
     pub fn messages(&self, channel_id: u32) -> Vec<ChatMessage> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.msgs.by_channel.get(&channel_id).cloned().unwrap_or_default())
             .unwrap_or_default()
     }
 
     pub fn dm_messages(&self, session: u32) -> Vec<ChatMessage> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.msgs.by_dm.get(&session).cloned().unwrap_or_default())
             .unwrap_or_default()
     }
 
     pub fn get_own_session(&self) -> Option<u32> {
-        self.inner.lock().ok().and_then(|s| s.conn.own_session)
+        self.inner.snapshot().lock().ok().and_then(|s| s.conn.own_session)
     }
 
     pub fn push_subscribed_channels(&self) -> Vec<u32> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.push_subscribed_channels.iter().copied().collect())
             .unwrap_or_default()
     }
 
     pub fn server_config(&self) -> ServerConfig {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| s.server.config.clone())
             .unwrap_or_default()
     }
 
     pub fn server_info(&self) -> ServerInfo {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| {
                 let vi = &s.server.version_info;
@@ -144,7 +144,7 @@ impl AppState {
     }
 
     pub fn debug_stats(&self) -> DebugStats {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .map(|s| {
                 let channel_msgs: usize = s.msgs.by_channel.values().map(Vec::len).sum();
@@ -180,7 +180,7 @@ impl AppState {
     }
 
     pub fn welcome_text(&self) -> Option<String> {
-        self.inner
+        self.inner.snapshot()
             .lock()
             .ok()
             .and_then(|s| s.server.welcome_text.clone())

--- a/crates/mumble-tauri/src/state/recording.rs
+++ b/crates/mumble-tauri/src/state/recording.rs
@@ -84,7 +84,7 @@ impl AppState {
         format: RecordingFormat,
     ) -> Result<String, String> {
         // Only one recording at a time.
-        if let Ok(state) = self.inner.lock() {
+        if let Ok(state) = self.inner.snapshot().lock() {
             if state.audio.recording_handle.is_some() {
                 return Err("Recording already in progress".into());
             }
@@ -92,7 +92,8 @@ impl AppState {
 
         // Gather template context.
         let (host, user, channel, speaker_buffers) = {
-            let state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let state = __session.lock().map_err(|e| e.to_string())?;
             let host = state.server.host.clone();
             let user = state.conn.own_name.clone();
             let channel = state
@@ -142,7 +143,9 @@ impl AppState {
 
         let path_str = file_path.to_string_lossy().to_string();
 
-        let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+        let __session = self.inner.snapshot();
+
+        let mut state = __session.lock().map_err(|e| e.to_string())?;
         state.audio.recording_handle = Some(RecordingHandle {
             _task: task,
             stop_flag,
@@ -157,7 +160,8 @@ impl AppState {
     /// Stop the current recording and finalize the file.
     pub fn stop_recording(&self) -> Result<String, String> {
         let handle = {
-            let mut state = self.inner.lock().map_err(|e| e.to_string())?;
+            let __session = self.inner.snapshot();
+            let mut state = __session.lock().map_err(|e| e.to_string())?;
             state
                 .audio.recording_handle
                 .take()
@@ -174,7 +178,8 @@ impl AppState {
 
     /// Get the current recording state.
     pub fn recording_state(&self) -> RecordingState {
-        let state = self.inner.lock().ok();
+        let __session = self.inner.snapshot();
+        let state = __session.lock().ok();
         match state.and_then(|s| s.audio.recording_handle.as_ref().map(|h| {
             (
                 h.file_path.to_string_lossy().to_string(),

--- a/crates/mumble-tauri/src/state/registry.rs
+++ b/crates/mumble-tauri/src/state/registry.rs
@@ -1,0 +1,158 @@
+//! Session registry: tracks every active server connection's
+//! [`SharedState`] keyed by [`ServerId`], plus which one is currently
+//! active.
+//!
+//! This is the central piece of the multi-server architecture.  Each
+//! connected server gets its own `Arc<Mutex<SharedState>>`; the
+//! registry maps `ServerId -> Arc<Mutex<SharedState>>` and remembers
+//! which session is "active" (the one that commands without an explicit
+//! `serverId` operate on).
+//!
+//! Phase B.1: the registry is in place but only ever holds at most one
+//! entry; behaviour is identical to the single-connection world.  Phase
+//! B.2 makes `connect` additive and `set_active_server` perform a real
+//! switch between concurrent sessions.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use super::sessions::{ServerId, SessionMeta};
+use super::SharedState;
+
+/// Inner mutable state of [`Registry`].
+#[derive(Default)]
+struct RegistryInner {
+    active: Option<ServerId>,
+    sessions: HashMap<ServerId, Arc<Mutex<SharedState>>>,
+}
+
+/// Concurrency-safe wrapper around the per-session map.
+#[derive(Default, Clone)]
+pub(crate) struct Registry {
+    inner: Arc<Mutex<RegistryInner>>,
+}
+
+impl Registry {
+    /// Return the active session's id, if any.
+    pub(crate) fn active_id(&self) -> Option<ServerId> {
+        self.inner.lock().ok().and_then(|g| g.active)
+    }
+
+    /// Look up a specific session's [`SharedState`] handle by id.
+    pub(crate) fn session(&self, id: ServerId) -> Option<Arc<Mutex<SharedState>>> {
+        self.inner.lock().ok()?.sessions.get(&id).cloned()
+    }
+
+    /// Insert a new session and mark it as active.  Returns the id.
+    pub(crate) fn register_active(
+        &self,
+        id: ServerId,
+        shared: Arc<Mutex<SharedState>>,
+    ) -> Option<Arc<Mutex<SharedState>>> {
+        let mut guard = self.inner.lock().ok()?;
+        let displaced = guard.sessions.insert(id, shared);
+        guard.active = Some(id);
+        displaced
+    }
+
+    /// Set which session is active.  Returns `Err` if `id` is unknown.
+    pub(crate) fn set_active(&self, id: ServerId) -> Result<(), String> {
+        let mut guard = self.inner.lock().map_err(|e| e.to_string())?;
+        if !guard.sessions.contains_key(&id) {
+            return Err(format!("unknown server id: {id}"));
+        }
+        guard.active = Some(id);
+        Ok(())
+    }
+
+    /// Remove a session.  If it was the active one, picks an arbitrary
+    /// remaining session as the new active (or `None` if empty).
+    pub(crate) fn remove(&self, id: ServerId) -> Option<Arc<Mutex<SharedState>>> {
+        let mut guard = self.inner.lock().ok()?;
+        let removed = guard.sessions.remove(&id);
+        if guard.active == Some(id) {
+            guard.active = guard.sessions.keys().copied().next();
+        }
+        removed
+    }
+
+    /// Snapshot the metadata of every known session, suitable for the
+    /// `list_servers` command.  Reads the per-session `SharedState` to
+    /// derive the live status, host, port, username, etc.
+    pub(crate) fn list_meta(&self) -> Vec<SessionMeta> {
+        let Ok(guard) = self.inner.lock() else {
+            return Vec::new();
+        };
+        guard
+            .sessions
+            .iter()
+            .filter_map(|(id, shared)| {
+                let s = shared.lock().ok()?;
+                Some(SessionMeta {
+                    id: *id,
+                    label: format_label(&s.conn.own_name, &s.server.host, s.server.port),
+                    host: s.server.host.clone(),
+                    port: s.server.port,
+                    username: s.conn.own_name.clone(),
+                    cert_label: s.cert_label.clone(),
+                    status: s.conn.status,
+                })
+            })
+            .collect()
+    }
+}
+
+fn format_label(username: &str, host: &str, port: u16) -> String {
+    if username.is_empty() {
+        format!("{host}:{port}")
+    } else {
+        format!("{username}@{host}:{port}")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "unwrap is acceptable in test code")]
+mod tests {
+    use super::*;
+
+    fn make_shared(host: &str, port: u16, user: &str) -> Arc<Mutex<SharedState>> {
+        let mut s = SharedState::default();
+        s.server.host = host.into();
+        s.server.port = port;
+        s.conn.own_name = user.into();
+        Arc::new(Mutex::new(s))
+    }
+
+    #[test]
+    fn register_and_resolve_active() {
+        let reg = Registry::default();
+        let id = ServerId::new();
+        let shared = make_shared("h", 1, "u");
+        let _ = reg.register_active(id, shared);
+        assert_eq!(reg.active_id(), Some(id));
+    }
+
+    #[test]
+    fn remove_picks_next_active() {
+        let reg = Registry::default();
+        let a = ServerId::new();
+        let b = ServerId::new();
+        let _ = reg.register_active(a, make_shared("a", 1, "u1"));
+        let _ = reg.register_active(b, make_shared("b", 2, "u2"));
+        assert_eq!(reg.active_id(), Some(b));
+        let _ = reg.remove(b);
+        assert_eq!(reg.active_id(), Some(a));
+        let _ = reg.remove(a);
+        assert!(reg.active_id().is_none());
+    }
+
+    #[test]
+    fn list_meta_synthesises_label() {
+        let reg = Registry::default();
+        let id = ServerId::new();
+        let _ = reg.register_active(id, make_shared("mumble.example", 64738, "alice"));
+        let metas = reg.list_meta();
+        assert_eq!(metas.len(), 1);
+        assert_eq!(metas[0].label, "alice@mumble.example:64738");
+    }
+}

--- a/crates/mumble-tauri/src/state/search.rs
+++ b/crates/mumble-tauri/src/state/search.rs
@@ -41,7 +41,9 @@ impl AppState {
             return Vec::new();
         }
 
-        let Ok(state) = self.inner.lock() else {
+        let __session = self.inner.snapshot();
+
+        let Ok(state) = __session.lock() else {
             return Vec::new();
         };
 
@@ -72,7 +74,8 @@ impl AppState {
     /// Photos are sorted newest-first (by timestamp if available, then
     /// insertion order as fallback).  Pagination is via `offset` / `limit`.
     pub fn get_photos(&self, offset: usize, limit: usize) -> Vec<PhotoEntry> {
-        let Ok(state) = self.inner.lock() else {
+        let __session = self.inner.snapshot();
+        let Ok(state) = __session.lock() else {
             return Vec::new();
         };
 

--- a/crates/mumble-tauri/src/state/sessions.rs
+++ b/crates/mumble-tauri/src/state/sessions.rs
@@ -1,0 +1,88 @@
+//! Multi-server session metadata.
+//!
+//! Phase A of the multi-server rollout: introduces the [`ServerId`]
+//! identifier and a lightweight [`SessionMeta`] record that the rest of
+//! the backend can use to refer to a connection by stable id.  The
+//! actual per-connection data (users, channels, messages, ...) still
+//! lives flat inside [`super::SharedState`]; future phases will migrate
+//! that data into a `HashMap<ServerId, ServerSession>`.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::types::ConnectionStatus;
+
+/// Stable identifier for a server connection.
+///
+/// Minted by the backend on each `connect` call.  Two connections to
+/// the same `host:port` (e.g. with different usernames) get distinct
+/// ids, so the frontend can show them as separate tabs.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ServerId(Uuid);
+
+impl ServerId {
+    /// Create a new random `ServerId`.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for ServerId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for ServerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::str::FromStr for ServerId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Uuid::parse_str(s).map(Self)
+    }
+}
+
+/// User-visible summary of a connected (or connecting) server.
+///
+/// Returned from the `list_servers` Tauri command and used by the
+/// frontend tab strip.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMeta {
+    pub id: ServerId,
+    pub label: String,
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub cert_label: Option<String>,
+    pub status: ConnectionStatus,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "unwrap is acceptable in test code")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_id_is_unique() {
+        let a = ServerId::new();
+        let b = ServerId::new();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn server_id_roundtrips_through_string() {
+        let id = ServerId::new();
+        let s = id.to_string();
+        let parsed: ServerId = s.parse().unwrap();
+        assert_eq!(id, parsed);
+    }
+}

--- a/crates/mumble-tauri/src/state/shared_handle.rs
+++ b/crates/mumble-tauri/src/state/shared_handle.rs
@@ -1,0 +1,106 @@
+//! Atomically-swappable handle to the active session's [`SharedState`].
+//!
+//! Wraps an [`arc_swap::ArcSwap`] holding the currently-active
+//! `Arc<Mutex<SharedState>>` so that switching the active server is a
+//! single atomic pointer swap, while background tasks (event loops,
+//! audio loops) that captured a specific session's
+//! `Arc<Mutex<SharedState>>` keep operating on that session even after
+//! the active one changes.
+//!
+//! Call sites obtain a snapshot of the current `Arc` first and then
+//! lock it normally:
+//!
+//! ```ignore
+//! let session = state.inner.snapshot();
+//! let mut s = session.lock().map_err(|e| e.to_string())?;
+//! ```
+//!
+//! The two-step pattern is required because a [`std::sync::MutexGuard`]
+//! borrows from its `Mutex`; binding the `Arc` to a local keeps the
+//! `Mutex` alive for the duration of the guard without resorting to
+//! unsafe lifetime extension.
+
+use std::sync::{Arc, Mutex};
+
+use arc_swap::ArcSwap;
+
+use super::SharedState;
+
+/// Cheaply-cloneable handle to the currently-active per-session state.
+#[derive(Clone)]
+pub(crate) struct SharedHandle {
+    swap: Arc<ArcSwap<Mutex<SharedState>>>,
+}
+
+impl SharedHandle {
+    /// Build a handle initially pointing at `initial`.
+    pub(crate) fn new(initial: Arc<Mutex<SharedState>>) -> Self {
+        Self {
+            swap: Arc::new(ArcSwap::new(initial)),
+        }
+    }
+
+    /// Replace the currently-active session's state with `next`.
+    /// Returns the previously-active `Arc`.
+    pub(crate) fn swap(&self, next: Arc<Mutex<SharedState>>) -> Arc<Mutex<SharedState>> {
+        self.swap.swap(next)
+    }
+
+    /// Take a snapshot of the currently-active session's `Arc`.  Bind
+    /// to a local before locking so the `Arc` outlives the guard.
+    pub(crate) fn snapshot(&self) -> Arc<Mutex<SharedState>> {
+        self.swap.load_full()
+    }
+
+    /// Alias for [`Self::snapshot`] kept for call sites that previously
+    /// spelled `Arc::clone(&state.inner)` / `state.inner.clone()`.
+    #[inline]
+    pub(crate) fn clone_arc(&self) -> Arc<Mutex<SharedState>> {
+        self.snapshot()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "unwrap is acceptable in test code")]
+mod tests {
+    use super::*;
+
+    fn make(host: &str) -> Arc<Mutex<SharedState>> {
+        let mut s = SharedState::default();
+        s.server.host = host.into();
+        Arc::new(Mutex::new(s))
+    }
+
+    #[test]
+    fn snapshot_returns_active_arc() {
+        let h = SharedHandle::new(make("alpha"));
+        let arc = h.snapshot();
+        assert_eq!(arc.lock().unwrap().server.host, "alpha");
+    }
+
+    #[test]
+    fn swap_changes_what_snapshot_returns() {
+        let h = SharedHandle::new(make("alpha"));
+        let _ = h.swap(make("beta"));
+        assert_eq!(h.snapshot().lock().unwrap().server.host, "beta");
+    }
+
+    #[test]
+    fn previous_snapshot_outlives_swap() {
+        let h = SharedHandle::new(make("alpha"));
+        let snap = h.snapshot();
+        let _ = h.swap(make("beta"));
+        assert_eq!(snap.lock().unwrap().server.host, "alpha");
+        assert_eq!(h.snapshot().lock().unwrap().server.host, "beta");
+    }
+
+    #[test]
+    fn mutating_via_snapshot_persists() {
+        let h = SharedHandle::new(make("alpha"));
+        {
+            let arc = h.snapshot();
+            arc.lock().unwrap().server.host = "gamma".into();
+        }
+        assert_eq!(h.snapshot().lock().unwrap().server.host, "gamma");
+    }
+}

--- a/crates/mumble-tauri/src/state/types.rs
+++ b/crates/mumble-tauri/src/state/types.rs
@@ -351,6 +351,17 @@ pub(crate) struct RejectedPayload {
     pub reject_type: Option<i32>,
 }
 
+/// Payload for the `server-disconnected` event.  Carries the id of
+/// the session that was disconnected so the frontend can route the
+/// event to the correct tab and avoid clobbering other sessions'
+/// state.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DisconnectedPayload {
+    pub server_id: Option<String>,
+    pub reason: Option<String>,
+}
+
 #[derive(Clone, Serialize)]
 pub(crate) struct UnreadPayload {
     /// `channel_id` -> unread count

--- a/crates/mumble-tauri/ui/src/components/__tests__/SessionUnreadRouting.test.ts
+++ b/crates/mumble-tauri/ui/src/components/__tests__/SessionUnreadRouting.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression tests for Phase F: per-session unread badges in the
+ * server tabs bar.  The Tauri "unread-changed" / "dm-unread-changed"
+ * listeners route counts to either the active session's
+ * `unreadCounts` / `dmUnreadCounts` (existing behaviour) or to the
+ * per-tab `sessionUnreadTotals` map (new) for non-active sessions.
+ *
+ * These tests reproduce that routing logic in isolation so the slice
+ * contract is locked in even if the listener wiring is refactored.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAppStore } from "../../store";
+
+type UnreadEvent = {
+  unreads: Record<number, number>;
+  serverId?: string | null;
+};
+
+/** Replicates the body of the "unread-changed" listener. */
+function applyUnreadChanged(event: UnreadEvent): void {
+  const { activeServerId } = useAppStore.getState();
+  const eventServerId = event.serverId ?? null;
+  const total = Object.values(event.unreads).reduce((a, b) => a + b, 0);
+  if (eventServerId && eventServerId !== activeServerId) {
+    useAppStore.setState((prev) => {
+      const next = { ...prev.sessionUnreadTotals };
+      const prevDm = next[`${eventServerId}:dm`] ?? 0;
+      next[`${eventServerId}:ch`] = total;
+      next[eventServerId] = total + prevDm;
+      return { sessionUnreadTotals: next };
+    });
+    return;
+  }
+  useAppStore.setState({ unreadCounts: event.unreads });
+}
+
+/** Replicates the body of the "dm-unread-changed" listener. */
+function applyDmUnreadChanged(event: UnreadEvent): void {
+  const { activeServerId } = useAppStore.getState();
+  const eventServerId = event.serverId ?? null;
+  const total = Object.values(event.unreads).reduce((a, b) => a + b, 0);
+  if (eventServerId && eventServerId !== activeServerId) {
+    useAppStore.setState((prev) => {
+      const next = { ...prev.sessionUnreadTotals };
+      const prevCh = next[`${eventServerId}:ch`] ?? 0;
+      next[`${eventServerId}:dm`] = total;
+      next[eventServerId] = total + prevCh;
+      return { sessionUnreadTotals: next };
+    });
+    return;
+  }
+  useAppStore.setState({ dmUnreadCounts: event.unreads });
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    activeServerId: "active-srv",
+    unreadCounts: {},
+    dmUnreadCounts: {},
+    sessionUnreadTotals: {},
+  });
+});
+
+describe("Phase F: per-session unread routing", () => {
+  it("active-session unreads land in unreadCounts, not in sessionUnreadTotals", () => {
+    applyUnreadChanged({ unreads: { 1: 3, 2: 1 }, serverId: "active-srv" });
+    const state = useAppStore.getState();
+    expect(state.unreadCounts).toEqual({ 1: 3, 2: 1 });
+    expect(state.sessionUnreadTotals).toEqual({});
+  });
+
+  it("non-active-session channel unreads accumulate in sessionUnreadTotals", () => {
+    applyUnreadChanged({ unreads: { 7: 4, 8: 2 }, serverId: "other-srv" });
+    const state = useAppStore.getState();
+    expect(state.unreadCounts).toEqual({});
+    expect(state.sessionUnreadTotals["other-srv"]).toBe(6);
+    expect(state.sessionUnreadTotals["other-srv:ch"]).toBe(6);
+  });
+
+  it("non-active-session DM unreads sum with channel unreads in the tab total", () => {
+    applyUnreadChanged({ unreads: { 7: 4 }, serverId: "other-srv" });
+    applyDmUnreadChanged({ unreads: { 99: 3, 100: 1 }, serverId: "other-srv" });
+    const state = useAppStore.getState();
+    expect(state.sessionUnreadTotals["other-srv:ch"]).toBe(4);
+    expect(state.sessionUnreadTotals["other-srv:dm"]).toBe(4);
+    expect(state.sessionUnreadTotals["other-srv"]).toBe(8);
+  });
+
+  it("missing serverId falls back to active-session behaviour", () => {
+    applyUnreadChanged({ unreads: { 1: 5 } });
+    const state = useAppStore.getState();
+    expect(state.unreadCounts).toEqual({ 1: 5 });
+    expect(state.sessionUnreadTotals).toEqual({});
+  });
+
+  it("multiple non-active sessions are tracked independently", () => {
+    applyUnreadChanged({ unreads: { 1: 2 }, serverId: "srv-a" });
+    applyUnreadChanged({ unreads: { 1: 7 }, serverId: "srv-b" });
+    const state = useAppStore.getState();
+    expect(state.sessionUnreadTotals["srv-a"]).toBe(2);
+    expect(state.sessionUnreadTotals["srv-b"]).toBe(7);
+  });
+
+  it("a fresh non-active update for a session replaces its prior channel count", () => {
+    applyUnreadChanged({ unreads: { 1: 5 }, serverId: "srv-a" });
+    applyUnreadChanged({ unreads: { 1: 0, 2: 1 }, serverId: "srv-a" });
+    const state = useAppStore.getState();
+    expect(state.sessionUnreadTotals["srv-a"]).toBe(1);
+  });
+});

--- a/crates/mumble-tauri/ui/src/components/layout/AddServerPopover.module.css
+++ b/crates/mumble-tauri/ui/src/components/layout/AddServerPopover.module.css
@@ -1,0 +1,165 @@
+.popover {
+  position: fixed;
+  width: 280px;
+  max-height: 360px;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-elevated, #1f2126);
+  border: 1px solid var(--color-glass-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  z-index: 1000;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--color-glass-border);
+}
+
+.title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.headerBtn {
+  border: 1px solid var(--color-glass-border);
+  background: transparent;
+  color: var(--color-text-primary);
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.headerBtn:hover {
+  background: var(--color-glass-medium);
+  border-color: var(--color-accent);
+}
+
+.searchRow {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-glass-border);
+}
+
+.searchInput {
+  width: 100%;
+  padding: 6px 8px;
+  background: var(--color-glass-subtle);
+  border: 1px solid var(--color-glass-border);
+  border-radius: 4px;
+  color: var(--color-text-primary);
+  font-size: 12px;
+  outline: none;
+}
+
+.searchInput:focus {
+  border-color: var(--color-accent);
+  background: var(--color-glass-medium);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--color-text-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.item:hover:not(:disabled) {
+  background: var(--color-glass-medium);
+}
+
+.item:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.pingDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dotProbing { background: #6b7280; }
+.dotOffline { background: #ef4444; }
+.dotGreat   { background: #22c55e; }
+.dotOkay    { background: #eab308; }
+.dotPoor    { background: #f97316; }
+
+.itemBody {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
+.itemLabel {
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.itemMeta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.connectedTag {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #22c55e;
+  letter-spacing: 0.04em;
+}
+
+.empty {
+  padding: 16px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.primaryBtn {
+  margin-top: 8px;
+  border: 1px solid var(--color-accent);
+  background: var(--color-accent-soft, transparent);
+  color: var(--color-text-primary);
+  font-size: 12px;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.primaryBtn:hover {
+  background: var(--color-accent);
+}

--- a/crates/mumble-tauri/ui/src/components/layout/AddServerPopover.tsx
+++ b/crates/mumble-tauri/ui/src/components/layout/AddServerPopover.tsx
@@ -1,0 +1,250 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { invoke } from "@tauri-apps/api/core";
+import { useNavigate } from "react-router-dom";
+import { useAppStore } from "../../store";
+import { getSavedServers, getServerPassword } from "../../serverStorage";
+import type { SavedServer, ServerPingResult } from "../../types";
+import styles from "./AddServerPopover.module.css";
+
+interface Props {
+  /** The button (or other element) the popover should anchor under. */
+  anchor: HTMLElement | null;
+  /** Called when the popover requests to close (outside-click, Esc, or
+   *  after a connect was issued). */
+  onClose: () => void;
+}
+
+/** Simple per-render ping cache to avoid re-pinging on every open within
+ *  a short window. */
+const POPOVER_PING_TTL_MS = 60_000;
+const popoverPingCache = new Map<string, { at: number; result: ServerPingResult }>();
+
+function pingClass(ping?: ServerPingResult): string {
+  if (!ping) return styles.dotProbing;
+  if (!ping.online) return styles.dotOffline;
+  const ms = ping.latency_ms ?? 0;
+  if (ms < 30) return styles.dotGreat;
+  if (ms < 70) return styles.dotOkay;
+  return styles.dotPoor;
+}
+
+function pingTitle(ping?: ServerPingResult): string {
+  if (!ping) return "Checking...";
+  if (!ping.online) return "Offline";
+  const ms = ping.latency_ms ?? 0;
+  return `${ms} ms`;
+}
+
+export default function AddServerPopover({ anchor, onClose }: Readonly<Props>) {
+  const navigate = useNavigate();
+  const connect = useAppStore((s) => s.connect);
+  const sessions = useAppStore((s) => s.sessions);
+
+  const [servers, setServers] = useState<SavedServer[] | null>(null);
+  const [pings, setPings] = useState<Record<string, ServerPingResult>>({});
+  const [query, setQuery] = useState("");
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const [pos, setPos] = useState<{ top: number; right: number } | null>(null);
+
+  // Position the popover under the anchor element using fixed coords so
+  // overflow on the parent tab bar doesn't clip it.
+  useLayoutEffect(() => {
+    if (!anchor) return;
+    const update = () => {
+      const rect = anchor.getBoundingClientRect();
+      setPos({
+        top: rect.bottom + 6,
+        right: Math.max(8, window.innerWidth - rect.right),
+      });
+    };
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [anchor]);
+
+  // Load saved servers on mount.
+  useEffect(() => {
+    let cancelled = false;
+    void getSavedServers().then((list) => {
+      if (cancelled) return;
+      setServers(list);
+      // Seed cached pings.
+      const seeded: Record<string, ServerPingResult> = {};
+      const now = Date.now();
+      for (const s of list) {
+        const key = `${s.host}:${s.port}`;
+        const hit = popoverPingCache.get(key);
+        if (hit && now - hit.at < POPOVER_PING_TTL_MS) {
+          seeded[s.id] = hit.result;
+        }
+      }
+      setPings(seeded);
+      // Fire fresh pings for the rest.
+      for (const s of list) {
+        const key = `${s.host}:${s.port}`;
+        const hit = popoverPingCache.get(key);
+        if (hit && now - hit.at < POPOVER_PING_TTL_MS) continue;
+        invoke<ServerPingResult>("ping_server", { host: s.host, port: s.port })
+          .then((result) => {
+            popoverPingCache.set(key, { at: Date.now(), result });
+            if (!cancelled) setPings((prev) => ({ ...prev, [s.id]: result }));
+          })
+          .catch(() => {
+            const result: ServerPingResult = {
+              online: false,
+              latency_ms: null,
+              user_count: null,
+              max_user_count: null,
+              server_version: null,
+            };
+            popoverPingCache.set(key, { at: Date.now(), result });
+            if (!cancelled) setPings((prev) => ({ ...prev, [s.id]: result }));
+          });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Outside-click + Esc to close.
+  useEffect(() => {
+    const onPointer = (e: PointerEvent) => {
+      const root = popoverRef.current;
+      if (!root) return;
+      const target = e.target instanceof Node ? e.target : null;
+      if (target && root.contains(target)) return;
+      // Don't close when clicking the anchor itself; let the anchor's
+      // onClick toggle decide.
+      if (target && anchor && anchor.contains(target)) return;
+      onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("pointerdown", onPointer);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("pointerdown", onPointer);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [anchor, onClose]);
+
+  const handleQuickConnect = useCallback(
+    async (server: SavedServer) => {
+      onClose();
+      const storedPw = await getServerPassword(server.id);
+      await connect(server.host, server.port, server.username, server.cert_label, storedPw);
+    },
+    [connect, onClose],
+  );
+
+  const handleAddNew = () => {
+    onClose();
+    navigate("/");
+  };
+
+  // Sessions keyed for quick lookup so we can mark already-connected entries.
+  const connectedKeys = new Set(
+    sessions.map((s) => `${s.host}:${s.port}:${s.username}`.toLowerCase()),
+  );
+
+  const filteredServers = (() => {
+    if (servers === null) return null;
+    const q = query.trim().toLowerCase();
+    if (!q) return servers;
+    return servers.filter((s) => {
+      const haystack = `${s.label ?? ""} ${s.host} ${s.username} ${s.port}`.toLowerCase();
+      return haystack.includes(q);
+    });
+  })();
+
+  if (!pos) return null;
+
+  return createPortal(
+    <div
+      ref={popoverRef}
+      className={styles.popover}
+      style={{ top: pos.top, right: pos.right }}
+      role="dialog"
+      aria-label="Connect to a server"
+    >
+      <div className={styles.header}>
+        <span className={styles.title}>Connect to a server</span>
+        <button
+          type="button"
+          className={styles.headerBtn}
+          onClick={handleAddNew}
+          title="Add a new server"
+        >
+          + New
+        </button>
+      </div>
+
+      {servers === null && <div className={styles.empty}>Loading...</div>}
+
+      {servers !== null && servers.length === 0 && (
+        <div className={styles.empty}>
+          <p>No saved servers yet.</p>
+          <button type="button" className={styles.primaryBtn} onClick={handleAddNew}>
+            Add your first server
+          </button>
+        </div>
+      )}
+
+      {servers !== null && servers.length > 0 && (
+        <>
+          <div className={styles.searchRow}>
+            <input
+              ref={searchInputRef}
+              type="text"
+              className={styles.searchInput}
+              placeholder="Search servers..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              autoFocus
+            />
+          </div>
+          {filteredServers && filteredServers.length === 0 ? (
+            <div className={styles.empty}>No matches</div>
+          ) : (
+            <ul className={styles.list} role="list">
+              {filteredServers?.map((s) => {
+            const key = `${s.host}:${s.port}:${s.username}`.toLowerCase();
+            const alreadyConnected = connectedKeys.has(key);
+            const ping = pings[s.id];
+            return (
+              <li key={s.id}>
+                <button
+                  type="button"
+                  className={styles.item}
+                  disabled={alreadyConnected}
+                  onClick={() => void handleQuickConnect(s)}
+                  title={alreadyConnected ? "Already connected" : `${s.username}@${s.host}:${s.port}`}
+                >
+                  <span className={`${styles.pingDot} ${pingClass(ping)}`} title={pingTitle(ping)} />
+                  <span className={styles.itemBody}>
+                    <span className={styles.itemLabel}>{s.label || s.host}</span>
+                    <span className={styles.itemMeta}>
+                      {s.username}
+                      {alreadyConnected && <span className={styles.connectedTag}>Connected</span>}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+            </ul>
+          )}
+        </>
+      )}
+    </div>,
+    document.body,
+  );
+}

--- a/crates/mumble-tauri/ui/src/components/layout/ServerTabsBar.module.css
+++ b/crates/mumble-tauri/ui/src/components/layout/ServerTabsBar.module.css
@@ -1,0 +1,175 @@
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 100%;
+  padding: 0 8px;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.bar::-webkit-scrollbar {
+  display: none;
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  max-width: 180px;
+  padding: 0 8px 0 10px;
+  border: 1px solid var(--color-glass-border);
+  border-radius: 6px;
+  background: var(--color-glass-subtle);
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.tab:hover {
+  background: var(--color-glass-medium);
+  color: var(--color-text-primary);
+}
+
+.tabActive {
+  background: var(--color-accent-soft, var(--color-glass-medium));
+  border-color: var(--color-accent);
+  color: var(--color-text-primary);
+}
+
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.statusConnected {
+  background: #22c55e;
+}
+
+.statusConnecting {
+  background: #eab308;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.statusDisconnected {
+  background: #ef4444;
+}
+
+.statusNew {
+  background: var(--color-accent, #6366f1);
+}
+
+.newTab {
+  border-style: dashed;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.unreadBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: #ef4444;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.15s ease;
+}
+
+.tab:hover .closeBtn,
+.tabActive .closeBtn {
+  opacity: 1;
+}
+
+.closeBtn:hover {
+  background: var(--color-danger-soft, rgba(239, 68, 68, 0.2));
+  color: #ef4444;
+}
+
+.addBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px dashed var(--color-glass-border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.addBtn:hover {
+  background: var(--color-glass-medium);
+  color: var(--color-text-primary);
+  border-style: solid;
+}
+
+.tabDragging {
+  opacity: 0.85;
+  cursor: grabbing;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transition: none;
+}
+
+.tabFloating {
+  background: var(--color-accent-soft, var(--color-glass-medium));
+  border: 1px solid var(--color-accent);
+  color: var(--color-text-primary);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+  cursor: grabbing;
+  opacity: 0.95;
+  transition: none;
+  will-change: transform;
+}
+
+.tabDropBefore {
+  box-shadow: -2px 0 0 0 var(--color-accent);
+}
+
+.tabDropAfter {
+  box-shadow: 2px 0 0 0 var(--color-accent);
+}

--- a/crates/mumble-tauri/ui/src/components/layout/ServerTabsBar.tsx
+++ b/crates/mumble-tauri/ui/src/components/layout/ServerTabsBar.tsx
@@ -1,0 +1,482 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useAppStore } from "../../store";
+import type { ServerId, SessionMeta } from "../../types";
+import ConfirmDialog from "../elements/ConfirmDialog";
+import AddServerPopover from "./AddServerPopover";
+import styles from "./ServerTabsBar.module.css";
+
+const TAB_ORDER_STORAGE_KEY = "fancy-mumble:server-tab-order";
+
+function loadStoredOrder(): ServerId[] {
+  try {
+    const raw = localStorage.getItem(TAB_ORDER_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((v) => typeof v === "string")) {
+      return parsed as ServerId[];
+    }
+  } catch {
+    // Ignore corrupt entries.
+  }
+  return [];
+}
+
+function saveStoredOrder(order: ServerId[]): void {
+  try {
+    localStorage.setItem(TAB_ORDER_STORAGE_KEY, JSON.stringify(order));
+  } catch {
+    // Quota exceeded / private mode - ignore.
+  }
+}
+
+/** Sort `sessions` according to the persisted user order; new sessions
+ *  not yet in the saved order are appended in their backend order. */
+function applyOrder(sessions: SessionMeta[], order: ServerId[]): SessionMeta[] {
+  if (sessions.length <= 1) return sessions;
+  const byId = new Map(sessions.map((s) => [s.id, s] as const));
+  const seen = new Set<ServerId>();
+  const ordered: SessionMeta[] = [];
+  for (const id of order) {
+    const meta = byId.get(id);
+    if (meta && !seen.has(id)) {
+      ordered.push(meta);
+      seen.add(id);
+    }
+  }
+  for (const meta of sessions) {
+    if (!seen.has(meta.id)) ordered.push(meta);
+  }
+  return ordered;
+}
+
+function statusClass(status: SessionMeta["status"]): string {
+  if (status === "connected") return styles.statusConnected;
+  if (status === "connecting") return styles.statusConnecting;
+  return styles.statusDisconnected;
+}
+
+function tabLabel(meta: SessionMeta): string {
+  if (meta.label && meta.label.trim().length > 0) return meta.label;
+  if (meta.host) return meta.host;
+  return meta.username || "Server";
+}
+
+export default function ServerTabsBar() {
+  const sessions = useAppStore((s) => s.sessions);
+  const activeServerId = useAppStore((s) => s.activeServerId);
+  const switchServer = useAppStore((s) => s.switchServer);
+  const refreshSessions = useAppStore((s) => s.refreshSessions);
+  const disconnectSession = useAppStore((s) => s.disconnectSession);
+  const sessionUnreadTotals = useAppStore((s) => s.sessionUnreadTotals);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // While the connect page is showing alongside existing sessions we
+  // render a synthetic "New connection" tab and treat it as active so
+  // the user can navigate back to a real session by clicking its tab.
+  const newTabActive = sessions.length > 0 && location.pathname === "/";
+
+  const [pendingDisconnect, setPendingDisconnect] = useState<SessionMeta | null>(null);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
+  const addBtnRef = useRef<HTMLButtonElement | null>(null);
+
+  // -- Drag-and-drop reordering (pointer-based) ----------------------
+  // We use pointer events instead of HTML5 drag-and-drop because the
+  // latter is unreliable inside Tauri's webview (drag ghost suppressed,
+  // drag-region attribute can swallow events).  The dragged tab is
+  // rendered as a portal-mounted floating clone with `position: fixed`
+  // so it can travel outside the bar's `overflow: auto` clip box.
+  const [tabOrder, setTabOrder] = useState<ServerId[]>(() => loadStoredOrder());
+  const tabRefs = useRef<Map<ServerId, HTMLDivElement>>(new Map());
+  const setTabRef = (id: ServerId) => (el: HTMLDivElement | null) => {
+    if (el) tabRefs.current.set(id, el);
+    else tabRefs.current.delete(id);
+  };
+  const floatingRef = useRef<HTMLDivElement | null>(null);
+  const dragStateRef = useRef<{
+    id: ServerId;
+    pointerId: number;
+    startX: number;
+    startY: number;
+    started: boolean;
+    grabOffsetX: number;
+    grabOffsetY: number;
+    width: number;
+    height: number;
+    rafId: number | null;
+    pendingX: number;
+    pendingY: number;
+  } | null>(null);
+  const [draggingId, setDraggingId] = useState<ServerId | null>(null);
+  const [floatingMeta, setFloatingMeta] = useState<{
+    meta: SessionMeta;
+    width: number;
+    height: number;
+    initialX: number;
+    initialY: number;
+  } | null>(null);
+  const [dropTarget, setDropTarget] = useState<{ id: ServerId; before: boolean } | null>(null);
+
+  const orderedSessions = useMemo(() => applyOrder(sessions, tabOrder), [sessions, tabOrder]);
+
+  // Keep the persisted order in sync whenever sessions appear/disappear so
+  // the saved list stays compact and reflects any append-on-connect order.
+  useEffect(() => {
+    if (sessions.length === 0) return;
+    const ids = orderedSessions.map((s) => s.id);
+    if (ids.length !== tabOrder.length || ids.some((id, i) => id !== tabOrder[i])) {
+      setTabOrder(ids);
+      saveStoredOrder(ids);
+    }
+  }, [sessions, orderedSessions, tabOrder]);
+
+  const DRAG_THRESHOLD_PX = 4;
+
+  const findTabUnderX = (clientX: number, excludeId: ServerId): { id: ServerId; before: boolean } | null => {
+    for (const meta of orderedSessions) {
+      if (meta.id === excludeId) continue;
+      const el = tabRefs.current.get(meta.id);
+      if (!el) continue;
+      const rect = el.getBoundingClientRect();
+      if (clientX >= rect.left && clientX <= rect.right) {
+        return { id: meta.id, before: clientX < rect.left + rect.width / 2 };
+      }
+    }
+    // Outside any tab: clamp to first/last.
+    const first = orderedSessions.find((s) => s.id !== excludeId);
+    const last = [...orderedSessions].reverse().find((s) => s.id !== excludeId);
+    if (!first || !last) return null;
+    const firstRect = tabRefs.current.get(first.id)?.getBoundingClientRect();
+    const lastRect = tabRefs.current.get(last.id)?.getBoundingClientRect();
+    if (firstRect && clientX < firstRect.left) return { id: first.id, before: true };
+    if (lastRect && clientX > lastRect.right) return { id: last.id, before: false };
+    return null;
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>, id: ServerId) => {
+    if (e.button !== 0) return;
+    if ((e.target as HTMLElement).closest(`.${styles.closeBtn}`)) return;
+    const el = e.currentTarget;
+    const rect = el.getBoundingClientRect();
+    dragStateRef.current = {
+      id,
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      started: false,
+      grabOffsetX: e.clientX - rect.left,
+      grabOffsetY: e.clientY - rect.top,
+      width: rect.width,
+      height: rect.height,
+      rafId: null,
+      pendingX: e.clientX,
+      pendingY: e.clientY,
+    };
+    el.setPointerCapture(e.pointerId);
+  };
+
+  const beginDrag = (id: ServerId, e: React.PointerEvent<HTMLDivElement>) => {
+    const meta = orderedSessions.find((s) => s.id === id);
+    const st = dragStateRef.current;
+    if (!meta || !st) return;
+    setDraggingId(id);
+    setFloatingMeta({
+      meta,
+      width: st.width,
+      height: st.height,
+      initialX: e.clientX - st.grabOffsetX,
+      initialY: st.startY - st.grabOffsetY,
+    });
+  };
+
+  const flushFloatingPosition = () => {
+    const st = dragStateRef.current;
+    if (!st) return;
+    st.rafId = null;
+    const el = floatingRef.current;
+    if (el) {
+      // Lock Y to the tab's original top so the clone stays on the
+      // tab bar; only X follows the cursor.
+      const x = st.pendingX - st.grabOffsetX;
+      const y = st.startY - st.grabOffsetY;
+      el.style.transform = `translate(${x}px, ${y}px)`;
+    }
+    const target = findTabUnderX(st.pendingX, st.id);
+    setDropTarget((prev) => {
+      if (!target) return prev === null ? prev : null;
+      if (prev?.id === target.id && prev.before === target.before) return prev;
+      return target;
+    });
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const st = dragStateRef.current;
+    if (!st || st.pointerId !== e.pointerId) return;
+    const dx = e.clientX - st.startX;
+    const dy = e.clientY - st.startY;
+    if (!st.started) {
+      if (Math.abs(dx) < DRAG_THRESHOLD_PX && Math.abs(dy) < DRAG_THRESHOLD_PX) return;
+      st.started = true;
+      beginDrag(st.id, e);
+    }
+    st.pendingX = e.clientX;
+    st.pendingY = e.clientY;
+    if (st.rafId === null) {
+      st.rafId = requestAnimationFrame(flushFloatingPosition);
+    }
+  };
+
+  const finishDrag = (commit: boolean) => {
+    const st = dragStateRef.current;
+    dragStateRef.current = null;
+    if (st?.rafId !== null && st?.rafId !== undefined) {
+      cancelAnimationFrame(st.rafId);
+    }
+    if (st && commit && st.started) {
+      const dropAt = dropTarget;
+      if (dropAt && dropAt.id !== st.id) {
+        const current = orderedSessions.map((s) => s.id);
+        const fromIdx = current.indexOf(st.id);
+        if (fromIdx !== -1) {
+          const next = [...current];
+          next.splice(fromIdx, 1);
+          let insertIdx = next.indexOf(dropAt.id);
+          if (!dropAt.before) insertIdx += 1;
+          next.splice(insertIdx, 0, st.id);
+          setTabOrder(next);
+          saveStoredOrder(next);
+        }
+      }
+    }
+    setDraggingId(null);
+    setFloatingMeta(null);
+    setDropTarget(null);
+    return st;
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLDivElement>, id: ServerId) => {
+    const st = dragStateRef.current;
+    const wasDragging = st?.started === true;
+    const tabEl = e.currentTarget;
+    if (st && tabEl.hasPointerCapture(st.pointerId)) {
+      tabEl.releasePointerCapture(st.pointerId);
+    }
+    finishDrag(true);
+    if (!wasDragging) {
+      handleSwitch(id);
+    }
+  };
+
+  const handlePointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
+    const st = dragStateRef.current;
+    if (st && e.currentTarget.hasPointerCapture(st.pointerId)) {
+      e.currentTarget.releasePointerCapture(st.pointerId);
+    }
+    finishDrag(false);
+  };
+
+
+  const handleSwitch = (id: ServerId) => {
+    // If we're on the connect page (new-tab dummy active), navigate
+    // back to the chat view; switchServer is a no-op when id matches
+    // the current activeServerId so this also handles the
+    // single-session case correctly.
+    if (location.pathname !== "/chat") {
+      navigate("/chat");
+    }
+    if (id === activeServerId) return;
+    void switchServer(id);
+  };
+
+  const handleDismissNewTab = (e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    setAddOpen(false);
+    navigate("/chat");
+  };
+
+  const handleCloseClick = (e: React.MouseEvent, meta: SessionMeta) => {
+    e.stopPropagation();
+    setPendingDisconnect(meta);
+  };
+
+  const handleConfirmDisconnect = async () => {
+    if (!pendingDisconnect) return;
+    setIsDisconnecting(true);
+    try {
+      await disconnectSession(pendingDisconnect.id);
+    } finally {
+      setIsDisconnecting(false);
+      setPendingDisconnect(null);
+      await refreshSessions();
+    }
+  };
+
+  const handleCancelDisconnect = () => {
+    setPendingDisconnect(null);
+  };
+
+  const handleAddClick = () => {
+    // When there are no saved sessions yet, fall back to the full
+    // connect page; otherwise toggle the dropdown.
+    if (sessions.length === 0) {
+      navigate("/");
+      return;
+    }
+    setAddOpen((open) => !open);
+  };
+
+  const renderAddButton = () => (
+    <button
+      ref={addBtnRef}
+      type="button"
+      className={styles.addBtn}
+      onClick={handleAddClick}
+      aria-label="Connect to a server"
+      aria-expanded={addOpen}
+      aria-haspopup="dialog"
+      title="Connect to a server"
+    >
+      +
+    </button>
+  );
+
+  const popover = addOpen ? (
+    <AddServerPopover anchor={addBtnRef.current} onClose={() => setAddOpen(false)} />
+  ) : null;
+
+  if (sessions.length === 0) {
+    return (
+      <>
+        <div className={styles.bar} data-tauri-drag-region>
+          {renderAddButton()}
+        </div>
+        {popover}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className={styles.bar} role="tablist" aria-label="Connected servers" data-tauri-drag-region>
+        {orderedSessions.map((meta) => {
+          const isActive = !newTabActive && meta.id === activeServerId;
+          const unreadTotal = isActive ? 0 : (sessionUnreadTotals[meta.id] ?? 0);
+          const isDragging = draggingId === meta.id;
+          const dropClass =
+            dropTarget?.id === meta.id && draggingId && draggingId !== meta.id
+              ? (dropTarget.before ? styles.tabDropBefore : styles.tabDropAfter)
+              : "";
+          const style: React.CSSProperties = isDragging
+            ? { visibility: "hidden" }
+            : {};
+          return (
+            <div
+              key={meta.id}
+              ref={setTabRef(meta.id)}
+              role="tab"
+              tabIndex={0}
+              aria-selected={isActive}
+              data-tauri-drag-region="false"
+              className={`${styles.tab} ${isActive ? styles.tabActive : ""} ${dropClass}`.trim()}
+              style={style}
+              onPointerDown={(e) => handlePointerDown(e, meta.id)}
+              onPointerMove={handlePointerMove}
+              onPointerUp={(e) => handlePointerUp(e, meta.id)}
+              onPointerCancel={handlePointerCancel}
+              onMouseDown={(e) => {
+                // Prevent Tauri's drag-region from claiming the mouse
+                // before our pointer handlers can run.
+                e.stopPropagation();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleSwitch(meta.id);
+                }
+              }}
+              title={`${meta.username}@${meta.host}:${meta.port}`}
+            >
+              <span className={`${styles.statusDot} ${statusClass(meta.status)}`} />
+              <span className={styles.label}>{tabLabel(meta)}</span>
+              {unreadTotal > 0 && (
+                <span className={styles.unreadBadge} aria-label={`${unreadTotal} unread`}>
+                  {unreadTotal > 99 ? "99+" : unreadTotal}
+                </span>
+              )}
+              <button
+                type="button"
+                className={styles.closeBtn}
+                onClick={(e) => handleCloseClick(e, meta)}
+                aria-label={`Disconnect from ${tabLabel(meta)}`}
+                title="Disconnect"
+              >
+                x
+              </button>
+            </div>
+          );
+        })}
+        {newTabActive && (
+          <div
+            role="tab"
+            aria-selected
+            tabIndex={0}
+            className={`${styles.tab} ${styles.tabActive} ${styles.newTab}`}
+            title="New connection"
+          >
+            <span className={`${styles.statusDot} ${styles.statusNew}`} />
+            <span className={styles.label}>New connection</span>
+            <button
+              type="button"
+              className={styles.closeBtn}
+              onClick={handleDismissNewTab}
+              aria-label="Dismiss new connection tab"
+              title="Dismiss"
+            >
+              x
+            </button>
+          </div>
+        )}
+        {renderAddButton()}
+      </div>
+
+      {popover}
+
+      {floatingMeta && createPortal(
+        <div
+          ref={floatingRef}
+          className={`${styles.tab} ${styles.tabFloating}`}
+          style={{
+            position: "fixed",
+            left: 0,
+            top: 0,
+            width: floatingMeta.width,
+            height: floatingMeta.height,
+            transform: `translate(${floatingMeta.initialX}px, ${floatingMeta.initialY}px)`,
+            pointerEvents: "none",
+            zIndex: 9999,
+          }}
+        >
+          <span className={`${styles.statusDot} ${statusClass(floatingMeta.meta.status)}`} />
+          <span className={styles.label}>{tabLabel(floatingMeta.meta)}</span>
+        </div>,
+        document.body,
+      )}
+
+      {pendingDisconnect && (
+        <ConfirmDialog
+          title="Disconnect from server"
+          body={`Disconnect from ${tabLabel(pendingDisconnect)}?`}
+          confirmLabel="Disconnect"
+          cancelLabel="Cancel"
+          danger
+          isConfirming={isDisconnecting}
+          onConfirm={() => void handleConfirmDisconnect()}
+          onCancel={handleCancelDisconnect}
+        />
+      )}
+    </>
+  );
+}

--- a/crates/mumble-tauri/ui/src/components/layout/TitleBar.module.css
+++ b/crates/mumble-tauri/ui/src/components/layout/TitleBar.module.css
@@ -18,8 +18,17 @@
   display: flex;
   align-items: center;
   gap: 12px;
+  flex-shrink: 0;
+  min-width: 0;
+}
+
+.tabsSection {
+  display: flex;
+  align-items: center;
   flex: 1;
   min-width: 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 .logo {

--- a/crates/mumble-tauri/ui/src/components/layout/TitleBar.tsx
+++ b/crates/mumble-tauri/ui/src/components/layout/TitleBar.tsx
@@ -1,6 +1,7 @@
 import { InfoFilledIcon, MaximizeIcon, MinimizeIcon, WindowCloseIcon } from "../../icons";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { isDesktopPlatform } from "../../utils/platform";
+import ServerTabsBar from "./ServerTabsBar";
 import styles from "./TitleBar.module.css";
 
 export default function TitleBar() {
@@ -31,6 +32,10 @@ export default function TitleBar() {
           <InfoFilledIcon width={20} height={20} />
         </div>
         <span className={styles.title}>Fancy Mumble</span>
+      </div>
+
+      <div className={styles.tabsSection} data-tauri-drag-region>
+        <ServerTabsBar />
       </div>
 
       <div className={styles.controls}>

--- a/crates/mumble-tauri/ui/src/hooks/useNotificationSounds.ts
+++ b/crates/mumble-tauri/ui/src/hooks/useNotificationSounds.ts
@@ -89,8 +89,30 @@ export function useNotificationSounds(
     let lastVoiceState: VoiceState | null = null;
     let lastChannel: number | null = null;
     let lastOwnSession: number | null | undefined = undefined;
+    let lastActiveServerId: string | null = null;
+
+    const resetPerServerRefs = () => {
+      prevUserCountRef.current = null;
+      prevChannelUsersRef.current = null;
+      prevChannelRef.current = null;
+    };
 
     const unsub = useAppStore.subscribe((state) => {
+      // When the active server changes, reset all per-server counters so
+      // the first snapshot from the new server does not trigger spurious
+      // join/leave/channel sounds.
+      if (state.activeServerId !== lastActiveServerId) {
+        lastActiveServerId = state.activeServerId;
+        resetPerServerRefs();
+        // Also reset cached refs so we don't compare stale slices.
+        lastUsersRef = null;
+        lastTalkingRef = null;
+        lastVoiceState = null;
+        lastChannel = null;
+        lastOwnSession = undefined;
+        return;
+      }
+
       const usersChanged = state.users !== lastUsersRef;
       const talkingChanged = state.talkingSessions !== lastTalkingRef;
       const voiceChanged = state.voiceState !== lastVoiceState;

--- a/crates/mumble-tauri/ui/src/pages/ChatPage.module.css
+++ b/crates/mumble-tauri/ui/src/pages/ChatPage.module.css
@@ -8,6 +8,122 @@
   z-index: 1;
 }
 
+/* --- Reconnect overlay (shown when active session is disconnected) */
+
+.reconnectPage {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  /* Inherit the global app gradient by leaving the background transparent. */
+  background: transparent;
+}
+
+.reconnectCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 36px 44px;
+  background: var(--color-glass);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-glass-border);
+  box-shadow: 0 8px 32px var(--color-overlay-medium);
+  max-width: 380px;
+  width: 100%;
+  text-align: center;
+}
+
+.reconnectIcon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--color-danger-bg);
+  border: 1px solid var(--color-danger-border-strong);
+  color: var(--color-danger);
+  font-size: 24px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.reconnectTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.reconnectServer {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.reconnectError {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-text-primary);
+  word-break: break-word;
+  line-height: 1.4;
+}
+
+.reconnectReasonBox {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: stretch;
+  width: 100%;
+  padding: 12px 14px;
+  margin-top: 4px;
+  border-radius: var(--radius-md);
+  background: var(--color-danger-bg);
+  border: 1px solid var(--color-danger-border);
+  text-align: left;
+}
+
+.reconnectReasonLabel {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-danger);
+}
+
+.reconnectBtn {
+  margin-top: 8px;
+  padding: 10px 28px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-hover));
+  color: var(--color-text-on-accent);
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 16px var(--color-accent-glow);
+  transition: opacity 0.2s, transform 0.1s, box-shadow 0.2s;
+}
+
+.reconnectBtn:disabled {
+  opacity: 0.6;
+  cursor: default;
+  box-shadow: none;
+}
+
+.reconnectBtn:not(:disabled):hover {
+  opacity: 0.92;
+  transform: translateY(-1px);
+}
+
+.reconnectBtn:not(:disabled):active {
+  transform: translateY(0);
+}
+
 /* --- Sidebar Drawer (narrow / mobile) --------------------------- */
 
 .sidebarContainer {

--- a/crates/mumble-tauri/ui/src/pages/ChatPage.tsx
+++ b/crates/mumble-tauri/ui/src/pages/ChatPage.tsx
@@ -1,4 +1,5 @@
 import { MenuIcon } from "../icons";
+import { invoke } from "@tauri-apps/api/core";
 import { lazy, Suspense, useEffect, useState, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAppStore } from "../store";
@@ -19,7 +20,14 @@ export default function ChatPage() {
   const selectedChannel = useAppStore((s) => s.selectedChannel);
   const selectedUser = useAppStore((s) => s.selectedUser);
   const selectedDmUser = useAppStore((s) => s.selectedDmUser);
+  const sessions = useAppStore((s) => s.sessions);
+  const activeServerId = useAppStore((s) => s.activeServerId);
+  const error = useAppStore((s) => s.error);
+  const connect = useAppStore((s) => s.connect);
+  const refreshSessions = useAppStore((s) => s.refreshSessions);
   const navigate = useNavigate();
+
+  const [isReconnecting, setIsReconnecting] = useState(false);
 
 
   // On desktop, track whether the viewport is narrow (<= 768px).
@@ -74,12 +82,13 @@ export default function ChatPage() {
     drawerRef,
   });
 
-  // Redirect to connect page if not connected.
+  // Redirect to connect page when disconnected with no open sessions.
+  // With open sessions we stay on /chat and show the reconnect overlay.
   useEffect(() => {
-    if (status === "disconnected") {
+    if (status === "disconnected" && sessions.length === 0) {
       navigate("/");
     }
-  }, [status, navigate]);
+  }, [status, sessions.length, navigate]);
 
   // On mobile, block the Android swipe-back gesture / hardware back button
   // from navigating away from the chat page (which would break the connection).
@@ -99,6 +108,49 @@ export default function ChatPage() {
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
   }, [isMobile, status]);
+
+  const handleReconnect = useCallback(async () => {
+    const meta = sessions.find((s) => s.id === activeServerId);
+    if (!meta) return;
+    setIsReconnecting(true);
+    try {
+      // Remove the dead session first so reconnect creates a fresh one.
+      await invoke("disconnect_server", { serverId: meta.id });
+      await refreshSessions();
+      await connect(meta.host, meta.port, meta.username, meta.certLabel);
+    } finally {
+      setIsReconnecting(false);
+    }
+  }, [sessions, activeServerId, connect, refreshSessions]);
+
+  if (status === "disconnected" && sessions.length > 0) {
+    const meta = sessions.find((s) => s.id === activeServerId);
+    const serverLabel = meta?.label || meta?.host || "Server";
+    const title = error ? "Disconnected" : "Connection lost";
+    return (
+      <div className={styles.reconnectPage}>
+        <div className={styles.reconnectCard}>
+          <div className={styles.reconnectIcon}>!</div>
+          <h2 className={styles.reconnectTitle}>{title}</h2>
+          <p className={styles.reconnectServer}>{serverLabel}</p>
+          {error && (
+            <div className={styles.reconnectReasonBox}>
+              <span className={styles.reconnectReasonLabel}>Reason</span>
+              <p className={styles.reconnectError}>{error}</p>
+            </div>
+          )}
+          <button
+            type="button"
+            className={styles.reconnectBtn}
+            onClick={() => void handleReconnect()}
+            disabled={isReconnecting}
+          >
+            {isReconnecting ? "Reconnecting..." : "Reconnect"}
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div ref={pageRef} className={styles.page}>

--- a/crates/mumble-tauri/ui/src/store.ts
+++ b/crates/mumble-tauri/ui/src/store.ts
@@ -171,6 +171,15 @@ async function probeFileServerCapabilities(): Promise<void> {
 
 let autoReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let manualDisconnectRequested = false;
+/** Sessions whose disconnect was triggered by the user (e.g. via the
+ *  tab close button).  The `server-disconnected` listener consults this
+ *  set so it does not surface a "Connection lost" overlay for what the
+ *  user just initiated themselves.  Entries are removed once handled. */
+const intentionallyClosingSessions = new Set<string>();
+/** Module-level handle to react-router's `navigate`.  Set by
+ *  `initEventListeners`; used by store actions that need to redirect
+ *  (e.g. `disconnectSession` falling back to the connect page). */
+let navigateRef: ((path: string) => void) | null = null;
 let isRestoringVoice = false;
 
 function clearAutoReconnectTimer(): void {
@@ -418,6 +427,35 @@ interface AppState {
     pchatRetentionDays?: number;
   }) => Promise<void>;
   deleteChannel: (channelId: number) => Promise<void>;
+
+  // -- Multi-server (Phase C) ------------------------------------
+  /** Snapshot of every backend session currently registered.  Survives
+   *  disconnects of individual sessions; only cleared by `refreshSessions`. */
+  sessions: import("./types").SessionMeta[];
+  /** Backend's currently-active session id (the one frontend commands
+   *  without an explicit serverId target).  `null` when no sessions. */
+  activeServerId: import("./types").ServerId | null;
+  /** Re-pull `list_servers` + `get_active_server` from the backend.
+   *  Idempotent; safe to call after any connect / disconnect. */
+  refreshSessions: () => Promise<void>;
+  /** Make `id` the backend's active session, then refresh per-session
+   *  data (channels / users / messages) for the new active session. */
+  switchServer: (id: import("./types").ServerId) => Promise<void>;
+  /** Tear down a single session by id (used by the tab-close button).
+   *  Suppresses the "Connection lost" overlay and switches the active
+   *  view to the next remaining session, or to the connect page when
+   *  no sessions remain. */
+  disconnectSession: (id: import("./types").ServerId) => Promise<void>;
+  /** Total unread message count per session (channels + DMs combined),
+   *  keyed by serverId.  Updated from `unread-changed` /
+   *  `dm-unread-changed` events for non-active sessions; the active
+   *  session's totals live in `unreadCounts` / `dmUnreadCounts`. */
+  sessionUnreadTotals: Record<string, number>;
+  /** Last disconnect / rejection reason per session, keyed by serverId.
+   *  Populated by `server-disconnected` / `connection-rejected` listeners
+   *  for *every* session (active or not) so that switching to a
+   *  disconnected tab restores its specific reason in the UI. */
+  sessionErrors: Record<string, string | null>;
 
   refreshState: () => Promise<void>;
   refreshMessages: (channelId: number) => Promise<void>;
@@ -697,6 +735,127 @@ export const useAppStore = create<AppState>((set, get) => ({
   ...INITIAL,
   disableLinkPreviews: false,
 
+  // Multi-server (Phase C): outside INITIAL so it survives single-session disconnects.
+  sessions: [],
+  activeServerId: null,
+  sessionUnreadTotals: {},
+  sessionErrors: {},
+
+  refreshSessions: async () => {
+    try {
+      const [sessions, activeServerId] = await Promise.all([
+        invoke<import("./types").SessionMeta[]>("list_servers"),
+        invoke<import("./types").ServerId | null>("get_active_server"),
+      ]);
+      set((prev) => {
+        // Drop per-tab badge entries for sessions that no longer exist.
+        const ids = new Set(sessions.map((s) => s.id));
+        const next: Record<string, number> = {};
+        for (const [k, v] of Object.entries(prev.sessionUnreadTotals)) {
+          const baseId = k.split(":")[0];
+          if (ids.has(baseId)) next[k] = v;
+        }
+        // Drop stored errors for sessions that no longer exist.
+        const nextErrors: Record<string, string | null> = {};
+        for (const [k, v] of Object.entries(prev.sessionErrors)) {
+          if (ids.has(k)) nextErrors[k] = v;
+        }
+        return { sessions, activeServerId, sessionUnreadTotals: next, sessionErrors: nextErrors };
+      });
+    } catch (e) {
+      console.error("refreshSessions error:", e);
+    }
+  },
+
+  switchServer: async (id) => {
+    try {
+      await invoke("set_active_server", { serverId: id });
+      // Clear our per-tab badge cache for the newly-active session;
+      // its unreads now live in `unreadCounts` / `dmUnreadCounts`.
+      set((prev) => {
+        const next = { ...prev.sessionUnreadTotals };
+        delete next[id];
+        delete next[`${id}:ch`];
+        delete next[`${id}:dm`];
+        return { activeServerId: id, sessionUnreadTotals: next };
+      });
+      // Sync global status/error from this session's own metadata so the
+      // ChatPage overlay reflects the tab the user just switched to,
+      // not whatever the previously-active tab's status was.
+      await get().refreshSessions().catch(() => {});
+      const { sessions, sessionErrors } = get();
+      const meta = sessions.find((s) => s.id === id);
+      const sessionStatus = meta?.status ?? "disconnected";
+      set({
+        status: sessionStatus,
+        error: sessionStatus === "connected" ? null : (sessionErrors[id] ?? null),
+      });
+      // Repopulate per-session data for the newly-active session.
+      await get().refreshState();
+      try {
+        const currentCh = await invoke<number | null>("get_current_channel");
+        set({ currentChannel: currentCh, selectedChannel: currentCh });
+        if (currentCh !== null) {
+          const messages = await invoke<ChatMessage[]>("get_messages", { channelId: currentCh });
+          set({ messages });
+        } else {
+          set({ messages: [] });
+        }
+      } catch (e) {
+        console.error("switchServer post-switch refresh error:", e);
+      }
+      try {
+        const ownSession = await invoke<number | null>("get_own_session");
+        set({ ownSession });
+      } catch {
+        // not connected; leave as-is.
+      }
+    } catch (e) {
+      console.error("switchServer error:", e);
+      throw e;
+    }
+  },
+
+  disconnectSession: async (id) => {
+    intentionallyClosingSessions.add(id);
+    const wasActive = get().activeServerId === id;
+    try {
+      await invoke("disconnect_server", { serverId: id });
+    } catch (e) {
+      console.error("disconnectSession error:", e);
+      intentionallyClosingSessions.delete(id);
+      throw e;
+    }
+    // Drop the cached error for the closed session.
+    set((prev) => {
+      if (prev.sessionErrors[id] == null) return prev;
+      const next = { ...prev.sessionErrors };
+      delete next[id];
+      return { sessionErrors: next };
+    });
+    // Refresh the sessions list and learn which session (if any) the
+    // backend made active in place of the one we just closed.
+    await get().refreshSessions().catch(() => {});
+    const { sessions: nextSessions, activeServerId: nextActive } = get();
+    if (wasActive) {
+      if (nextActive && nextSessions.some((s) => s.id === nextActive)) {
+        // The backend rebound the active session to a remaining one.
+        // Reflect its status / error / data in the global store.
+        await get().switchServer(nextActive).catch(() => {});
+      } else {
+        // No sessions left - reset to the empty connect-page state.
+        manualDisconnectRequested = true;
+        offloadManager.dispose().catch(() => {});
+        volumeAppliedSessions.clear();
+        clearReadReceipts();
+        set({ ...INITIAL });
+        invoke("update_badge_count", { count: null }).catch(() => {});
+        navigateRef?.("/");
+      }
+    }
+    intentionallyClosingSessions.delete(id);
+  },
+
   connect: async (host, port, username, certLabel, password) => {
     manualDisconnectRequested = false;
     clearAutoReconnectTimer();
@@ -728,10 +887,24 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   disconnect: async () => {
-    manualDisconnectRequested = true;
     clearAutoReconnectTimer();
+    const activeId = get().activeServerId;
+    if (activeId) {
+      // Delegate to the multi-session-aware path so closing the active
+      // session via the sidebar button behaves identically to closing
+      // it via the tab close button: the backend rebinds `inner` to
+      // the next session and the UI follows along instead of flashing
+      // a misleading "Connection lost" overlay on the next tab.
+      try {
+        await get().disconnectSession(activeId);
+      } catch (e) {
+        console.error("disconnect error:", e);
+      }
+      return;
+    }
+    // No active session - fall back to a full local reset.
+    manualDisconnectRequested = true;
     try {
-      // Clean up offloaded temp files before resetting state.
       await offloadManager.dispose();
       await invoke("disconnect");
     } catch (e) {
@@ -741,6 +914,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     clearReadReceipts();
     set({ ...INITIAL });
     invoke("update_badge_count", { count: null }).catch(() => {});
+    useAppStore.getState().refreshSessions().catch(() => {});
   },
 
   selectChannel: async (id) => {
@@ -1587,7 +1761,12 @@ export async function requestLinkPreview(urls: string[], requestId: string): Pro
 export async function initEventListeners(
   navigate: (path: string) => void,
 ): Promise<UnlistenFn[]> {
+  navigateRef = navigate;
   const unlisteners: UnlistenFn[] = [];
+
+  // Bootstrap the multi-server session list once at startup so the
+  // sessions slice reflects whatever the backend already has.
+  useAppStore.getState().refreshSessions().catch(() => {});
 
   // Ensure notification permissions and channel are set up (Android 8+ / 13+).
   try {
@@ -1661,6 +1840,24 @@ export async function initEventListeners(
         mutedPushChannels: mutedPush,
         userVolumes: storedVolumes,
         bootstrapStage: "Fetching channels and users...",
+      });
+
+      // Refresh the multi-server session list so any newly-connected
+      // server appears in the sessions slice immediately.
+      useAppStore.getState().refreshSessions().catch(() => {
+        // best-effort; the sessions list will be repopulated on next event.
+      }).then(() => {
+        // Clear any stale per-session error stored from a prior disconnect
+        // for this newly-connected session.
+        const { activeServerId } = useAppStore.getState();
+        if (activeServerId) {
+          useAppStore.setState((prev) => {
+            if (prev.sessionErrors[activeServerId] == null) return prev;
+            const next = { ...prev.sessionErrors };
+            delete next[activeServerId];
+            return { sessionErrors: next };
+          });
+        }
       });
 
       // Load channels/users/messages, then resolve identity, then
@@ -1762,24 +1959,83 @@ export async function initEventListeners(
 
   // Connection dropped.
   unlisteners.push(
-    await listen<string | null>("server-disconnected", (event) => {
-      // Clean up offloaded temp files.
-      offloadManager.dispose().catch(() => {});
-      volumeAppliedSessions.clear();
-      clearReadReceipts();
-      // Preserve error / password-prompt state that was set by connection-rejected.
-      const { error: currentError, passwordRequired: pwRequired, pendingConnect: pending } = useAppStore.getState();
-      // If a password prompt is already pending, keep the rejection error
-      // instead of overwriting it with a generic disconnect message.
-      const reason = pwRequired ? currentError : (event.payload ?? currentError);
-      useAppStore.setState({ ...INITIAL, error: reason, passwordRequired: pwRequired, pendingConnect: pending });
-      invoke("update_badge_count", { count: null }).catch(() => {});
-      navigate("/");
+    await listen<{ serverId?: string | null; reason: string | null } | string | null>(
+      "server-disconnected",
+      async (event) => {
+        // Normalise: backend now always sends an object payload, but tolerate
+        // a bare reason string for forwards/backwards compatibility.
+        const payload = event.payload;
+        const eventServerId = typeof payload === "object" && payload !== null
+          ? (payload.serverId ?? null)
+          : null;
+        const eventReason = typeof payload === "string"
+          ? payload
+          : (typeof payload === "object" && payload !== null ? payload.reason : null);
 
-      if (!manualDisconnectRequested && !pwRequired && pending) {
-        scheduleAutoReconnect(pending);
-      }
-    }),
+        const { activeServerId } = useAppStore.getState();
+        // Only treat the event as affecting the active session if the
+        // backend explicitly tagged it with the active session's id.
+        // A missing/null serverId means "unknown" - we must not assume
+        // it belongs to the currently-focused tab, otherwise closing a
+        // background session would clobber the foreground one.
+        const isActiveSession =
+          eventServerId !== null && eventServerId === activeServerId;
+
+        // If the user explicitly closed this session via the tab close
+        // button, the `disconnectSession` action manages the UI handoff
+        // (refresh + switch to next active tab).  Skip the listener's
+        // own state-clobbering cleanup so we don't flash a misleading
+        // "Connection lost" overlay on the *next* tab.
+        if (eventServerId && intentionallyClosingSessions.has(eventServerId)) {
+          await useAppStore.getState().refreshSessions().catch(() => {});
+          return;
+        }
+
+        // Always refresh the sessions list so the disconnected tab updates
+        // its status dot / badge regardless of which tab was affected.
+        await useAppStore.getState().refreshSessions().catch(() => {});
+
+        // Always remember the disconnect reason for this specific session
+        // so the user sees the correct reason when they switch tabs.
+        // Skip overwriting an already-stored reason with null - kick events
+        // may be followed by a generic on_disconnected with no reason.
+        if (eventServerId && eventReason) {
+          useAppStore.setState((prev) => ({
+            sessionErrors: { ...prev.sessionErrors, [eventServerId]: eventReason },
+          }));
+        }
+
+        if (!isActiveSession) {
+          // A non-active session disconnected: do not touch the active
+          // session's state (status, channels, users, etc.).  The tab
+          // bar already reflects the new status; nothing else to do.
+          return;
+        }
+
+        // Active session was the one that disconnected — proceed with
+        // the full local cleanup.
+        offloadManager.dispose().catch(() => {});
+        volumeAppliedSessions.clear();
+        clearReadReceipts();
+        const { error: currentError, passwordRequired: pwRequired, pendingConnect: pending } = useAppStore.getState();
+        // If a password prompt is already pending, keep the rejection error
+        // instead of overwriting it with a generic disconnect message.
+        const reason = pwRequired ? currentError : (eventReason ?? currentError);
+        useAppStore.setState({ ...INITIAL, error: reason, passwordRequired: pwRequired, pendingConnect: pending });
+        invoke("update_badge_count", { count: null }).catch(() => {});
+
+        const { sessions } = useAppStore.getState();
+        if (sessions.length === 0 || pwRequired) {
+          navigate("/");
+        } else {
+          navigate("/chat");
+        }
+
+        if (!manualDisconnectRequested && !pwRequired && pending) {
+          scheduleAutoReconnect(pending);
+        }
+      },
+    ),
   );
 
   // Channel / user list changed - debounce rapid-fire updates.
@@ -1848,25 +2104,71 @@ export async function initEventListeners(
     }),
 
     // Unread counts changed.
-    await listen<{ unreads: Record<number, number> }>(
+    await listen<{ unreads: Record<number, number>; serverId?: string | null }>(
       "unread-changed",
       (event) => {
+        const { activeServerId } = useAppStore.getState();
+        const eventServerId = event.payload.serverId ?? null;
+        // Compute total for this session (sum of unreads).
+        const total = Object.values(event.payload.unreads).reduce((a, b) => a + b, 0);
+        if (eventServerId && eventServerId !== activeServerId) {
+          // Non-active session: only update its per-tab badge total.
+          useAppStore.setState((prev) => {
+            // Combine channel total with whatever DM total we last saw
+            // for this session (we store the channel total alone here;
+            // dm-unread updates merge in the same way).
+            const next = { ...prev.sessionUnreadTotals };
+            const prevDm = next[`${eventServerId}:dm`] ?? 0;
+            next[`${eventServerId}:ch`] = total;
+            next[eventServerId] = total + prevDm;
+            return { sessionUnreadTotals: next };
+          });
+          return;
+        }
         useAppStore.setState({ unreadCounts: event.payload.unreads });
         updateBadgeCount();
       },
     ),
 
     // DM unread counts changed.
-    await listen<{ unreads: Record<number, number> }>(
+    await listen<{ unreads: Record<number, number>; serverId?: string | null }>(
       "dm-unread-changed",
       (event) => {
+        const { activeServerId } = useAppStore.getState();
+        const eventServerId = event.payload.serverId ?? null;
+        const total = Object.values(event.payload.unreads).reduce((a, b) => a + b, 0);
+        if (eventServerId && eventServerId !== activeServerId) {
+          useAppStore.setState((prev) => {
+            const next = { ...prev.sessionUnreadTotals };
+            const prevCh = next[`${eventServerId}:ch`] ?? 0;
+            next[`${eventServerId}:dm`] = total;
+            next[eventServerId] = total + prevCh;
+            return { sessionUnreadTotals: next };
+          });
+          return;
+        }
         useAppStore.setState({ dmUnreadCounts: event.payload.unreads });
         updateBadgeCount();
       },
     ),
 
     // Server rejected the connection.
-    await listen<{ reason: string; reject_type: number | null }>("connection-rejected", (event) => {
+    await listen<{ serverId?: string | null; reason: string; reject_type: number | null }>("connection-rejected", async (event) => {
+      // Always remember the rejection reason for this session so the
+      // user sees it when they switch to its tab.
+      const eventServerId = event.payload.serverId ?? null;
+      if (eventServerId) {
+        useAppStore.setState((prev) => ({
+          sessionErrors: { ...prev.sessionErrors, [eventServerId]: event.payload.reason },
+        }));
+      }
+      // Ignore rejections targeting non-active sessions: the matching
+      // server-disconnected event will surface them via the per-session
+      // status and the reconnect overlay when the user opens that tab.
+      const { activeServerId } = useAppStore.getState();
+      if (eventServerId !== null && eventServerId !== activeServerId) {
+        return;
+      }
       const rt = event.payload.reject_type;
       // WrongUserPW = 3, WrongServerPW = 4
       const isPasswordError = rt === 3 || rt === 4;
@@ -1879,15 +2181,21 @@ export async function initEventListeners(
           bootstrapStage: null,
           // pendingConnect was set by the connect action - keep it.
         });
-      } else {
-        useAppStore.setState({
-          status: "disconnected",
-          error: event.payload.reason,
-          pendingConnect: null,
-          bootstrapStage: null,
-        });
+        navigate("/");
+        return;
       }
-      navigate("/");
+      useAppStore.setState({
+        status: "disconnected",
+        error: event.payload.reason,
+        pendingConnect: null,
+        bootstrapStage: null,
+      });
+      // Stay on /chat when other tabs remain so the reconnect overlay
+      // surfaces the kick/ban reason via `error`.  Connect-time failures
+      // (no other sessions) fall back to the connect page.
+      await useAppStore.getState().refreshSessions().catch(() => {});
+      const { sessions } = useAppStore.getState();
+      navigate(sessions.length > 0 ? "/chat" : "/");
     }),
 
     // Listen request was denied by the server - revert the UI.

--- a/crates/mumble-tauri/ui/src/types.ts
+++ b/crates/mumble-tauri/ui/src/types.ts
@@ -107,6 +107,28 @@ export interface PendingMessage {
 
 export type ConnectionStatus = "disconnected" | "connecting" | "connected";
 
+/**
+ * Multi-server: stable identifier for a connected server, minted by the
+ * backend on each `connect` call.  Phase A: surfaced via the
+ * `list_servers` / `get_active_server` / `set_active_server` Tauri
+ * commands and stamped onto every emitted event payload as `serverId`.
+ */
+export type ServerId = string;
+
+/**
+ * User-visible summary of a connected (or connecting) server returned
+ * by the `list_servers` command.
+ */
+export interface SessionMeta {
+  id: ServerId;
+  label: string;
+  host: string;
+  port: number;
+  username: string;
+  certLabel: string | null;
+  status: ConnectionStatus;
+}
+
 export interface ServerLogEntry {
   timestamp_ms: number;
   message: string;


### PR DESCRIPTION
## Description

Add support for multiple server connections at the same time

## Changes

<!-- Summarise the key changes. -->

- Add multiple connections
- Connect to multiple servers
- switch between multiple servers, without having to reconnect

## Checklist

- [x] Code compiles without warnings (`cargo clippy --workspace -- -D warnings`)
- [x] TypeScript type-checks (`npx tsc --noEmit`)
- [x] Frontend tests pass (`npm test`)
- [x] Rust tests pass (`cargo test --package mumble-protocol --features opus-codec --lib`)
- [x] New functionality has tests
- [x] Boy Scout Rule applied - files left cleaner than found
