### PR TITLE
feat: audio device selection, expired attachments, DM UX improvements

### DIFF
--- a/crates/mumble-tauri/src/audio/rodio_desktop.rs
+++ b/crates/mumble-tauri/src/audio/rodio_desktop.rs
@@ -19,9 +19,9 @@ use mumble_protocol::audio::capture::AudioCapture;
 use mumble_protocol::audio::mixer::{SpeakerBuffers, SpeakerVolumes};
 use mumble_protocol::audio::sample::{AudioFormat, AudioFrame};
 use mumble_protocol::error::{Error, Result};
-use rodio::microphone::MicrophoneBuilder;
+use rodio::microphone::{available_inputs, MicrophoneBuilder};
 use rodio::source::Source;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 // -- Capture (Microphone) -------------------------------------------
 
@@ -44,11 +44,12 @@ pub struct RodioCapture {
     _capture_thread: Option<thread::JoinHandle<()>>,
     volume: Arc<AtomicU32>,
     pending: Vec<f32>,
+    device_name: Option<String>,
 }
 
 impl RodioCapture {
     pub fn new(
-        _device_name: Option<&str>,
+        device_name: Option<&str>,
         frame_size: usize,
         volume: Arc<AtomicU32>,
     ) -> Result<Self> {
@@ -60,7 +61,17 @@ impl RodioCapture {
             _capture_thread: None,
             volume,
             pending: Vec::with_capacity(frame_size * 2),
+            device_name: device_name.map(str::to_owned),
         })
+    }
+
+    /// Look up an input device by display name (as returned by
+    /// `get_audio_devices`).  Returns `None` if no matching device is
+    /// found, in which case the caller should fall back to the
+    /// default device.
+    fn find_input_by_name(name: &str) -> Option<rodio::microphone::Input> {
+        let inputs = available_inputs().ok()?;
+        inputs.into_iter().find(|i| i.to_string() == name)
     }
 }
 
@@ -107,9 +118,30 @@ impl AudioCapture for RodioCapture {
     }
 
     fn start(&mut self) -> Result<()> {
-        let builder = MicrophoneBuilder::new()
-            .default_device()
-            .map_err(|e| Error::InvalidState(format!("No input device: {e}")))?
+        let device_builder = MicrophoneBuilder::new();
+        let with_device = if let Some(name) = self.device_name.as_deref() {
+            match Self::find_input_by_name(name) {
+                Some(input) => {
+                    debug!("rodio capture: using selected input device '{name}'");
+                    device_builder
+                        .device(input)
+                        .map_err(|e| Error::InvalidState(format!("Open input '{name}': {e}")))?
+                }
+                None => {
+                    warn!(
+                        "rodio capture: selected input device '{name}' not found, falling back to default"
+                    );
+                    device_builder
+                        .default_device()
+                        .map_err(|e| Error::InvalidState(format!("No input device: {e}")))?
+                }
+            }
+        } else {
+            device_builder
+                .default_device()
+                .map_err(|e| Error::InvalidState(format!("No input device: {e}")))?
+        };
+        let builder = with_device
             .default_config()
             .map_err(|e| Error::InvalidState(format!("Input config: {e}")))?
             .prefer_channel_counts([MONO_CHANNELS])
@@ -470,11 +502,12 @@ pub struct RodioMixingPlayback {
     buffers: SpeakerBuffers,
     speaker_volumes: SpeakerVolumes,
     volume: Arc<AtomicU32>,
+    device_name: Option<String>,
 }
 
 impl RodioMixingPlayback {
     pub fn new(
-        _device_name: Option<&str>,
+        device_name: Option<&str>,
         volume: Arc<AtomicU32>,
         buffers: SpeakerBuffers,
         speaker_volumes: SpeakerVolumes,
@@ -485,15 +518,48 @@ impl RodioMixingPlayback {
             buffers,
             speaker_volumes,
             volume,
+            device_name: device_name.map(str::to_owned),
+        })
+    }
+
+    /// Look up a cpal output device by description name (matching the
+    /// names returned by `get_output_devices`).
+    fn find_output_by_name(name: &str) -> Option<cpal::Device> {
+        use cpal::traits::{DeviceTrait, HostTrait};
+        let host = cpal::default_host();
+        host.output_devices().ok()?.find(|d| {
+            d.description()
+                .ok()
+                .map(|desc| desc.name().to_string())
+                .as_deref()
+                == Some(name)
         })
     }
 }
 
 impl super::MixingPlayback for RodioMixingPlayback {
     fn start(&mut self) -> Result<()> {
-        // Open the default output device and get a mixer handle.
-        let device_sink = rodio::stream::DeviceSinkBuilder::from_default_device()
-            .map_err(|e| Error::InvalidState(format!("Open output device: {e}")))?
+        let builder = if let Some(name) = self.device_name.as_deref() {
+            match Self::find_output_by_name(name) {
+                Some(device) => {
+                    debug!("rodio playback: using selected output device '{name}'");
+                    rodio::stream::DeviceSinkBuilder::from_device(device).map_err(|e| {
+                        Error::InvalidState(format!("Open output '{name}': {e}"))
+                    })?
+                }
+                None => {
+                    warn!(
+                        "rodio playback: selected output device '{name}' not found, falling back to default"
+                    );
+                    rodio::stream::DeviceSinkBuilder::from_default_device()
+                        .map_err(|e| Error::InvalidState(format!("Open output device: {e}")))?
+                }
+            }
+        } else {
+            rodio::stream::DeviceSinkBuilder::from_default_device()
+                .map_err(|e| Error::InvalidState(format!("Open output device: {e}")))?
+        };
+        let device_sink = builder
             .open_stream()
             .map_err(|e| Error::InvalidState(format!("Open output stream: {e}")))?;
         let mixer = device_sink.mixer().clone();

--- a/crates/mumble-tauri/ui/src/App.tsx
+++ b/crates/mumble-tauri/ui/src/App.tsx
@@ -12,7 +12,7 @@ import { useSpoilerReveal } from "./hooks/useSpoilerReveal";
 import { useCodeHighlight } from "./hooks/useCodeHighlight";
 import { useWatchLifecycle } from "./components/chat/watch/useWatchLifecycle";
 import { DEFAULT_NOTIFICATION_SOUNDS } from "./pages/settings/NotificationsPanel";
-import type { NotificationSoundSettings } from "./types";
+import type { NotificationSoundSettings, AudioSettings } from "./types";
 import TitleBar from "./components/layout/TitleBar";
 import ConnectPage from "./pages/ConnectPage";
 import LoadingSplash from "./components/elements/LoadingSplash";
@@ -108,11 +108,20 @@ function MainApp() {
     getNotificationSounds().then((ns) => {
       if (ns) setNotifSounds(ns);
     });
-    getSavedAudioSettings().then((saved) => {
-      if (saved) {
-        invoke("set_audio_settings", { settings: saved }).catch((e) =>
-          console.error("Startup audio settings error:", e),
-        );
+    getSavedAudioSettings().then(async (saved) => {
+      if (!saved) return;
+      try {
+        // Merge persisted values on top of the backend defaults so any
+        // fields missing from older saves don't cause serde to reject
+        // the invoke.  Without this merge the call silently fails and
+        // the saved device (and other settings) only get applied once
+        // the user opens the settings page, which performs its own
+        // merge before re-invoking.
+        const cfg = await invoke<AudioSettings>("get_audio_settings");
+        const merged: AudioSettings = { ...cfg, ...saved };
+        await invoke("set_audio_settings", { settings: merged });
+      } catch (e) {
+        console.error("Startup audio settings error:", e);
       }
     });
     loadShortcuts().then((sc) => {

--- a/crates/mumble-tauri/ui/src/components/chat/ChatHeader.tsx
+++ b/crates/mumble-tauri/ui/src/components/chat/ChatHeader.tsx
@@ -125,13 +125,8 @@ export default function ChatHeader({
   hasNewDownloads,
   onDownloads,
 }: ChatHeaderProps) {
-  let prefix: string;
-  if (isDm) prefix = "@";
-  else prefix = "#";
-
-  let subtitle: string;
-  if (isDm) subtitle = "Direct Message";
-  else subtitle = `${memberCount} members`;
+  const prefix = isDm ? "@" : "#";
+  const subtitle = isDm ? "Direct Message" : `${memberCount} members`;
 
   const privateBadge = isDm;
   const isStreaming = !!broadcastInfo;

--- a/crates/mumble-tauri/ui/src/components/chat/FileAttachmentCard.module.css
+++ b/crates/mumble-tauri/ui/src/components/chat/FileAttachmentCard.module.css
@@ -149,3 +149,21 @@
   background: var(--color-accent-medium, rgba(100, 160, 255, 0.15));
   border-color: var(--color-accent, #89b4fa);
 }
+
+/* ---- Expired link state ---------------------------------------- */
+
+.expiredCard {
+  border-color: var(--color-warning-border, rgba(255, 170, 80, 0.35));
+  background: var(--color-warning-bg, rgba(255, 170, 80, 0.06));
+}
+
+.expiredIcon {
+  color: var(--color-warning, #f0a04b);
+  background: rgba(255, 170, 80, 0.1);
+}
+
+.expiredMessage {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--color-warning, #f0a04b);
+}

--- a/crates/mumble-tauri/ui/src/components/chat/FileAttachmentCard.tsx
+++ b/crates/mumble-tauri/ui/src/components/chat/FileAttachmentCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -103,6 +103,9 @@ export default function FileAttachmentCard({ info }: FileAttachmentCardProps) {
   const [saved, setSaved] = useState(false);
   const [savedPath, setSavedPath] = useState<string | null>(null);
   const [lightboxOpen, setLightboxOpen] = useState(false);
+  const initiallyExpired =
+    info.expiresAt != null && info.expiresAt > 0 && info.expiresAt * 1000 < Date.now();
+  const [expired, setExpired] = useState<boolean>(initiallyExpired);
 
   const kind = previewKindForFilename(info.filename);
   const previewable = kind === "image" || kind === "audio" || kind === "video";
@@ -127,7 +130,50 @@ export default function FileAttachmentCard({ info }: FileAttachmentCardProps) {
 
   const closeLightbox = useCallback(() => setLightboxOpen(false), []);
 
-  const canOpenInBrowser = info.mode === "public" || info.mode === "password";
+  // Switch to expired state automatically once the announced expiry
+  // timestamp passes, without waiting for a network failure.
+  useEffect(() => {
+    if (savedPath || expired) return;
+    if (info.expiresAt == null || info.expiresAt <= 0) return;
+    const msUntilExpiry = info.expiresAt * 1000 - Date.now();
+    if (msUntilExpiry <= 0) {
+      setExpired(true);
+      return;
+    }
+    const timer = globalThis.setTimeout(() => setExpired(true), msUntilExpiry + 500);
+    return () => globalThis.clearTimeout(timer);
+  }, [info.expiresAt, savedPath, expired]);
+
+  // Probe the URL when an inline preview fails to load. The file-server
+  // returns HTTP 404 with a JSON body of `{"error":"link expired"}` for
+  // expired signed URLs - distinguish that from a generic load failure.
+  const probeForExpiry = useCallback(async () => {
+    try {
+      const resp = await fetch(info.url, { method: "GET" });
+      if (resp.status === 404) {
+        let body = "";
+        try {
+          body = await resp.text();
+        } catch {
+          // ignore body parse failure
+        }
+        if (body.toLowerCase().includes("expired")) {
+          setExpired(true);
+          return;
+        }
+      }
+      setError("Preview failed to load.");
+    } catch {
+      setError("Preview failed to load.");
+    }
+  }, [info.url]);
+
+  const handlePreviewError = useCallback(() => {
+    if (expired) return;
+    void probeForExpiry();
+  }, [expired, probeForExpiry]);
+
+  const canOpenInBrowser = (info.mode === "public" || info.mode === "password") && !expired;
 
   const onSave = useCallback(async () => {
     setBusy(true);
@@ -160,7 +206,12 @@ export default function FileAttachmentCard({ info }: FileAttachmentCardProps) {
       setSaved(true);
       setSavedPath(dest);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.toLowerCase().includes("expired")) {
+        setExpired(true);
+      } else {
+        setError(msg);
+      }
     } finally {
       setBusy(false);
     }
@@ -181,6 +232,7 @@ export default function FileAttachmentCard({ info }: FileAttachmentCardProps) {
             alt={info.filename}
             className={styles.previewImage}
             loading="lazy"
+            onError={handlePreviewError}
           />
         </button>
       );
@@ -188,7 +240,13 @@ export default function FileAttachmentCard({ info }: FileAttachmentCardProps) {
     if (kind === "audio") {
       return (
         <div className={styles.previewAudioWrap}>
-          <audio controls preload="none" src={previewSrc} className={styles.previewAudio}>
+          <audio
+            controls
+            preload="none"
+            src={previewSrc}
+            className={styles.previewAudio}
+            onError={handlePreviewError}
+          >
             <track kind="captions" />
           </audio>
         </div>
@@ -196,13 +254,50 @@ export default function FileAttachmentCard({ info }: FileAttachmentCardProps) {
     }
     if (kind === "video") {
       return (
-        <video controls preload="metadata" src={previewSrc} className={styles.previewVideo}>
+        <video
+          controls
+          preload="metadata"
+          src={previewSrc}
+          className={styles.previewVideo}
+          onError={handlePreviewError}
+        >
           <track kind="captions" />
         </video>
       );
     }
     return null;
   })();
+
+  if (expired) {
+    return (
+      <div className={`${styles.card} ${styles.expiredCard}`}>
+        <div className={styles.cardRow}>
+          <div className={`${styles.icon} ${styles.expiredIcon}`} aria-hidden="true">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="9" />
+              <polyline points="12 7 12 12 15 14" />
+            </svg>
+          </div>
+          <div className={styles.body}>
+            <div className={styles.filename}>{info.filename}</div>
+            <div className={styles.expiredMessage}>
+              This download link has expired and is no longer available.
+            </div>
+            <div className={styles.meta}>
+              {formatBytes(info.sizeBytes)}
+              {info.mode !== "public" && <span className={styles.badge}>{info.mode}</span>}
+              {info.expiresAt != null && info.expiresAt > 0 && (
+                <span className={styles.expiry}>
+                  expired {new Date(info.expiresAt * 1000).toLocaleString()}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.card}>

--- a/crates/mumble-tauri/ui/src/components/elements/MessageActionBar.tsx
+++ b/crates/mumble-tauri/ui/src/components/elements/MessageActionBar.tsx
@@ -98,14 +98,6 @@ export default function MessageActionBar({
       onClick: () => { void startWatch(); },
     });
   }
-  if (onCopyText) {
-    kebabItems.push({
-      id: "copy",
-      label: "Copy text",
-      icon: <CopyIcon width={14} height={14} />,
-      onClick: () => onCopyText(message),
-    });
-  }
   if (canDelete && onDelete) {
     kebabItems.push({
       id: "delete",
@@ -158,6 +150,19 @@ export default function MessageActionBar({
       >
         <QuoteIcon width={16} height={16} />
       </button>
+
+      {/* Copy text */}
+      {onCopyText && (
+        <button
+          type="button"
+          className={styles.actionBtn}
+          title="Copy text"
+          aria-label="Copy message text"
+          onClick={() => onCopyText(message)}
+        >
+          <CopyIcon width={16} height={16} />
+        </button>
+      )}
 
       {/* Kebab menu */}
       {kebabItems.length > 0 && (

--- a/crates/mumble-tauri/ui/src/components/layout/ServerTabsBar.tsx
+++ b/crates/mumble-tauri/ui/src/components/layout/ServerTabsBar.tsx
@@ -391,6 +391,15 @@ export default function ServerTabsBar() {
                 // before our pointer handlers can run.
                 e.stopPropagation();
               }}
+              onAuxClick={(e) => {
+                // Middle-click closes the tab (with the same confirm
+                // dialog as the X button).
+                if (e.button === 1) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setPendingDisconnect(meta);
+                }
+              }}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();

--- a/crates/mumble-tauri/ui/src/components/sidebar/ChannelInfoPanel.tsx
+++ b/crates/mumble-tauri/ui/src/components/sidebar/ChannelInfoPanel.tsx
@@ -41,6 +41,7 @@ export default function ChannelInfoPanel({ onClose }: ChannelInfoPanelProps) {
 
   const users = useAppStore((s) => s.users);
   const selectDmUser = useAppStore((s) => s.selectDmUser);
+  const selectedDmUser = useAppStore((s) => s.selectedDmUser);
 
   // Key holder state
   const keyHolders = useAppStore((s) => s.keyHolders);
@@ -272,6 +273,7 @@ export default function ChannelInfoPanel({ onClose }: ChannelInfoPanelProps) {
                 <div key={u.session} className={styles.memberRow}>
                   <UserListItem
                     user={u}
+                    active={selectedDmUser === u.session}
                     onClick={() => selectDmUser(u.session)}
                     onContextMenu={(e) => openUserCtxMenu(e, u.session)}
                   />

--- a/crates/mumble-tauri/ui/src/components/sidebar/flat/ModernChannelList.module.css
+++ b/crates/mumble-tauri/ui/src/components/sidebar/flat/ModernChannelList.module.css
@@ -196,6 +196,29 @@
   background: var(--color-glass-hover);
 }
 
+.memberItemActive {
+  background: var(--color-glass-active, rgba(99, 102, 241, 0.15));
+  box-shadow: inset 2px 0 0 var(--color-accent, rgba(99, 102, 241, 0.85));
+}
+
+.dmUnreadBadge {
+  flex-shrink: 0;
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 99px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+  background: var(--color-accent);
+  box-shadow: 0 0 6px rgba(42, 171, 238, 0.4);
+}
+
 .memberTalking {
   background: rgba(46, 204, 113, 0.12);
 }

--- a/crates/mumble-tauri/ui/src/components/sidebar/flat/ModernChannelList.tsx
+++ b/crates/mumble-tauri/ui/src/components/sidebar/flat/ModernChannelList.tsx
@@ -65,13 +65,17 @@ interface MemberItemProps {
   readonly user: UserEntry;
   readonly isTalking: boolean;
   readonly isBroadcasting: boolean;
+  readonly isActive?: boolean;
   readonly onContextMenu?: (e: React.MouseEvent, user: UserEntry) => void;
   readonly onClick?: (session: number) => void;
 }
 
-function MemberItem({ user, isTalking, isBroadcasting, onContextMenu, onClick }: MemberItemProps) {
+function MemberItem({ user, isTalking, isBroadcasting, isActive, onContextMenu, onClick }: MemberItemProps) {
   const ownSession = useAppStore((s) => s.ownSession);
+  const selectedDmUser = useAppStore((s) => s.selectedDmUser);
+  const dmUnread = useAppStore((s) => s.dmUnreadCounts[user.session] ?? 0);
   const isSelf = ownSession === user.session;
+  const active = isActive ?? (!isSelf && selectedDmUser === user.session);
   const canMoveUser = useAppStore((s) => {
     const ch = s.channels.find((c) => c.id === user.channel_id);
     return ch?.permissions != null && (ch.permissions & PERM_MOVE) !== 0;
@@ -109,7 +113,7 @@ function MemberItem({ user, isTalking, isBroadcasting, onContextMenu, onClick }:
       <button
         ref={itemRef}
         type="button"
-        className={`${styles.memberItem} ${isTalking ? styles.memberTalking : ""}`}
+        className={`${styles.memberItem} ${active ? styles.memberItemActive : ""} ${isTalking ? styles.memberTalking : ""}`}
         onMouseEnter={handleEnter}
         onMouseLeave={handleLeave}
         onContextMenu={handleContextMenu}
@@ -145,6 +149,11 @@ function MemberItem({ user, isTalking, isBroadcasting, onContextMenu, onClick }:
           <span className={styles.liveBadge} title="Sharing screen">
             <ScreenShareIcon width={10} height={10} />
             Live
+          </span>
+        )}
+        {dmUnread > 0 && (
+          <span className={styles.dmUnreadBadge} title={`${dmUnread} unread direct message${dmUnread === 1 ? "" : "s"}`}>
+            {dmUnread > 99 ? "99+" : dmUnread}
           </span>
         )}
       </button>

--- a/crates/mumble-tauri/ui/src/components/sidebar/modern/ChannelIconList.module.css
+++ b/crates/mumble-tauri/ui/src/components/sidebar/modern/ChannelIconList.module.css
@@ -205,6 +205,29 @@
   background: var(--color-glass-hover);
 }
 
+.memberRowActive {
+  background: var(--color-glass-active, rgba(99, 102, 241, 0.15));
+  box-shadow: inset 2px 0 0 var(--color-accent, rgba(99, 102, 241, 0.85));
+}
+
+.dmUnreadBadge {
+  flex-shrink: 0;
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 99px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  color: #fff;
+  background: var(--color-accent);
+  box-shadow: 0 0 6px rgba(42, 171, 238, 0.4);
+}
+
 .memberTalking {
   background: rgba(46, 204, 113, 0.1);
 }

--- a/crates/mumble-tauri/ui/src/components/sidebar/modern/ChannelIconList.tsx
+++ b/crates/mumble-tauri/ui/src/components/sidebar/modern/ChannelIconList.tsx
@@ -92,13 +92,17 @@ interface MemberRowProps {
   readonly user: UserEntry;
   readonly isTalking: boolean;
   readonly isBroadcasting: boolean;
+  readonly isActive?: boolean;
   readonly onContextMenu?: (e: React.MouseEvent, user: UserEntry) => void;
   readonly onClick?: (session: number) => void;
 }
 
-function MemberRow({ user, isTalking, isBroadcasting, onContextMenu, onClick }: MemberRowProps) {
+function MemberRow({ user, isTalking, isBroadcasting, isActive, onContextMenu, onClick }: MemberRowProps) {
   const ownSession = useAppStore((s) => s.ownSession);
+  const selectedDmUser = useAppStore((s) => s.selectedDmUser);
+  const dmUnread = useAppStore((s) => s.dmUnreadCounts[user.session] ?? 0);
   const isSelf = ownSession === user.session;
+  const active = isActive ?? (!isSelf && selectedDmUser === user.session);
   const canMoveUser = useAppStore((s) => {
     const ch = s.channels.find((c) => c.id === user.channel_id);
     return ch?.permissions != null && (ch.permissions & PERM_MOVE) !== 0;
@@ -136,7 +140,7 @@ function MemberRow({ user, isTalking, isBroadcasting, onContextMenu, onClick }: 
       <button
         ref={itemRef}
         type="button"
-        className={`${styles.memberRow} ${isTalking ? styles.memberTalking : ""}`}
+        className={`${styles.memberRow} ${active ? styles.memberRowActive : ""} ${isTalking ? styles.memberTalking : ""}`}
         onMouseEnter={handleEnter}
         onMouseLeave={handleLeave}
         onContextMenu={handleContextMenu}
@@ -172,6 +176,11 @@ function MemberRow({ user, isTalking, isBroadcasting, onContextMenu, onClick }: 
           <span className={styles.liveBadge} title="Sharing screen">
             <ScreenShareIcon width={10} height={10} />
             Live
+          </span>
+        )}
+        {dmUnread > 0 && (
+          <span className={styles.dmUnreadBadge} title={`${dmUnread} unread direct message${dmUnread === 1 ? "" : "s"}`}>
+            {dmUnread > 99 ? "99+" : dmUnread}
           </span>
         )}
       </button>

--- a/crates/mumble-tauri/ui/src/components/user/UserProfileView.tsx
+++ b/crates/mumble-tauri/ui/src/components/user/UserProfileView.tsx
@@ -93,11 +93,11 @@ export default function UserProfileView() {
   const selectedDmUser = useAppStore((s) => s.selectedDmUser);
   const users = useAppStore((s) => s.users);
   const selectUser = useAppStore((s) => s.selectUser);
+  const selectDmUser = useAppStore((s) => s.selectDmUser);
 
   // In DM mode, always show the DM partner's profile even if the user
   // closed the generic profile panel.
   const effectiveSession = selectedUser ?? selectedDmUser;
-  const isDmProfile = selectedUser === null && selectedDmUser !== null;
 
   const user: UserEntry | undefined = useMemo(
     () => users.find((u) => u.session === effectiveSession),
@@ -106,10 +106,14 @@ export default function UserProfileView() {
 
   if (!user) return null;
 
+  const handleClose = selectedDmUser === null
+    ? () => selectUser(null)
+    : () => { void selectDmUser(selectedDmUser); };
+
   return (
     <UserProfilePanel
       user={user}
-      onClose={isDmProfile ? undefined : () => selectUser(null)}
+      onClose={handleClose}
     />
   );
 }

--- a/crates/mumble-tauri/ui/src/store.ts
+++ b/crates/mumble-tauri/ui/src/store.ts
@@ -1245,6 +1245,18 @@ export const useAppStore = create<AppState>((set, get) => ({
   selectUser: (session) => set({ selectedUser: session }),
 
   selectDmUser: async (session) => {
+    // Toggle: clicking the currently-selected DM user a second time
+    // switches back to the channel the local user is currently in.
+    const { selectedDmUser, currentChannel, selectChannel } = get();
+    if (selectedDmUser === session) {
+      if (currentChannel == null) {
+        set({ selectedDmUser: null, dmMessages: [], selectedUser: null });
+      } else {
+        await selectChannel(currentChannel);
+        set({ selectedUser: null });
+      }
+      return;
+    }
     set({ selectedDmUser: session, selectedChannel: null, messages: [], selectedUser: session });
     try {
       await invoke("select_dm_user", { session });


### PR DESCRIPTION
## Description

<!-- What does this PR do? Link related issues with "Closes #123". -->

## Changes

- Fix audio device selection: capture and playback now use the configured
  device name and fall back to default if not found. Startup settings
  apply is fixed by merging persisted values onto backend defaults first.
- FileAttachmentCard detects expired links via timer, preview error probe,
  and save error; renders a dedicated expired UI instead of a broken state.
- User rows in sidebar show active highlight and DM unread badges.
- DM deselect: clicking the active DM user again navigates back to channel.
- "Copy text" promoted to a visible action button in MessageActionBar.
- Middle-click on a server tab opens the disconnect-confirm dialog.

## Checklist

- [x] Code compiles without warnings (`cargo clippy --workspace -- -D warnings`)
- [x] TypeScript type-checks (`npx tsc --noEmit`)
- [x] Frontend tests pass (`npm test`)
- [x] Rust tests pass (`cargo test --package mumble-protocol --features opus-codec --lib`)
- [x] New functionality has tests
- [x] Boy Scout Rule applied - files left cleaner than found
