### PR TITLE
fix(#97): Fix bug where FancyMumble does not transmit audio on server…

### DIFF
--- a/crates/mumble-protocol/src/client.rs
+++ b/crates/mumble-protocol/src/client.rs
@@ -16,7 +16,6 @@ use crate::error::{Error, Result};
 use crate::event::EventHandler;
 use crate::fancy_codec::{self, FancyCodec};
 use crate::message::{ControlMessage, ServerMessage, UdpMessage};
-use crate::transport::audio_codec::AudioPacketCodec;
 use crate::transport::ocb2::Ocb2CryptState;
 use crate::proto::mumble_tcp;
 use crate::state::ServerState;
@@ -299,7 +298,13 @@ async fn event_loop<H: EventHandler>(
             biased;
             item = wq_receiver.recv() => Some(item),
             Some(msg) = audio_out_rx.recv() => {
-                send_one_audio_packet(&msg, &mut udp_sender, &outbound_tx, &mut outbound_audio_count);
+                send_one_audio_packet(
+                    &msg,
+                    &mut udp_sender,
+                    &outbound_tx,
+                    &mut outbound_audio_count,
+                    state.connection.supports_protobuf_audio(),
+                );
                 None
             }
             Ok(()) = force_tcp_rx.changed() => {
@@ -310,6 +315,7 @@ async fn event_loop<H: EventHandler>(
                         force_tcp, &stored_crypto, &udp_config, &wq_sender,
                         &mut udp_sender, &mut udp_reader_task, &mut udp_resync_tx,
                         &outbound_tx, &state.decrypt_stats, &mut handler,
+                        state.connection.supports_protobuf_audio(),
                     ).await;
                 }
                 None
@@ -538,6 +544,7 @@ impl<H: EventHandler> EventLoopCtx<'_, H> {
                             self.udp_resync_tx,
                             &self.decrypt_stats,
                             self.handler,
+                            self.state.connection.supports_protobuf_audio(),
                         )
                         .await;
                     }
@@ -600,8 +607,12 @@ impl<H: EventHandler> EventLoopCtx<'_, H> {
 
     /// Send a UDP ping to keep the NAT mapping alive.
     async fn send_udp_ping(&mut self) {
+        let protobuf_audio = self.state.connection.supports_protobuf_audio();
         if let Some(sender) = &mut self.udp_sender {
-            let payload = crate::transport::udp::encode_udp_message(&udp_ping_message());
+            let payload = crate::transport::udp::encode_udp_message_for(
+                &udp_ping_message(),
+                protobuf_audio,
+            );
             if let Err(e) = sender.send_raw(&payload).await {
                 warn!("UDP ping send failed: {e}");
             }
@@ -610,13 +621,15 @@ impl<H: EventHandler> EventLoopCtx<'_, H> {
 
     /// Send outbound UDP audio, preferring real UDP with TCP tunnel fallback.
     async fn send_udp_output(&mut self, messages: &[UdpMessage]) {
+        let protobuf_audio = self.state.connection.supports_protobuf_audio();
         for udp_msg in messages {
             let UdpMessage::Audio(audio) = udp_msg else {
                 continue;
             };
 
             let use_tunnel = if let Some(sender) = &mut self.udp_sender {
-                let payload = crate::transport::udp::encode_udp_message(udp_msg);
+                let payload =
+                    crate::transport::udp::encode_udp_message_for(udp_msg, protobuf_audio);
                 if let Err(e) = sender.send_raw(&payload).await {
                     warn!("UDP send failed, falling back to TCP tunnel: {e}");
                     true
@@ -629,7 +642,7 @@ impl<H: EventHandler> EventLoopCtx<'_, H> {
 
             if use_tunnel {
                 let tunnel_data =
-                    crate::transport::audio_codec::ProtobufAudioCodec::encode(audio);
+                    crate::transport::audio_codec::encode_tunnel_audio(audio, protobuf_audio);
                 let tunnel = ControlMessage::UdpTunnel(tunnel_data);
                 if self.outbound_tx.send(tunnel).await.is_err() {
                     error!("outbound channel closed");
@@ -753,6 +766,7 @@ fn send_one_audio_packet(
     udp_sender: &mut Option<UdpSender>,
     outbound_tx: &mpsc::Sender<ControlMessage>,
     counter: &mut u64,
+    protobuf_audio: bool,
 ) {
     let UdpMessage::Audio(audio) = msg else {
         return;
@@ -767,7 +781,7 @@ fn send_one_audio_packet(
     }
 
     let sent_udp = if let Some(sender) = udp_sender.as_mut() {
-        let payload = crate::transport::udp::encode_udp_message(msg);
+        let payload = crate::transport::udp::encode_udp_message_for(msg, protobuf_audio);
         match sender.try_send_raw(&payload) {
             Ok(true) => true,
             Ok(false) => {
@@ -785,7 +799,7 @@ fn send_one_audio_packet(
 
     if !sent_udp {
         let tunnel_data =
-            crate::transport::audio_codec::ProtobufAudioCodec::encode(audio);
+            crate::transport::audio_codec::encode_tunnel_audio(audio, protobuf_audio);
         let tunnel = ControlMessage::UdpTunnel(tunnel_data);
         if outbound_tx.try_send(tunnel).is_err() {
             warn!("TCP tunnel channel full, dropping audio packet");
@@ -815,6 +829,7 @@ async fn handle_crypt_setup<H: EventHandler>(
     udp_resync_tx: &mut Option<mpsc::Sender<Vec<u8>>>,
     decrypt_stats: &crate::transport::ocb2::SharedPacketStats,
     handler: &mut H,
+    protobuf_audio: bool,
 ) {
     // Full key setup: key + client_nonce + server_nonce all present
     let (Some(key), Some(client_nonce), Some(server_nonce)) =
@@ -863,6 +878,7 @@ async fn handle_crypt_setup<H: EventHandler>(
         udp_resync_tx,
         decrypt_stats,
         handler,
+        protobuf_audio,
     )
     .await;
 }
@@ -880,6 +896,7 @@ async fn handle_force_tcp_change<H: EventHandler>(
     outbound_tx: &mpsc::Sender<ControlMessage>,
     decrypt_stats: &crate::transport::ocb2::SharedPacketStats,
     handler: &mut H,
+    protobuf_audio: bool,
 ) {
     if force_tcp {
         // Tear down active UDP transport.
@@ -905,6 +922,7 @@ async fn handle_force_tcp_change<H: EventHandler>(
                 udp_resync_tx,
                 decrypt_stats,
                 handler,
+                protobuf_audio,
             )
             .await;
         } else {
@@ -927,6 +945,7 @@ async fn start_udp<H: EventHandler>(
     udp_resync_tx: &mut Option<mpsc::Sender<Vec<u8>>>,
     decrypt_stats: &crate::transport::ocb2::SharedPacketStats,
     handler: &mut H,
+    protobuf_audio: bool,
 ) {
 
     // Initialize encrypt CryptState (for outbound audio)
@@ -993,7 +1012,10 @@ async fn start_udp<H: EventHandler>(
     // public UDP endpoint (NAT traversal).  Without this the server
     // has no address to forward audio to.
     if let Some(sender) = udp_sender.as_mut() {
-        let payload = crate::transport::udp::encode_udp_message(&udp_ping_message());
+        let payload = crate::transport::udp::encode_udp_message_for(
+            &udp_ping_message(),
+            protobuf_audio,
+        );
         if let Err(e) = sender.send_raw(&payload).await {
             warn!("failed to send initial UDP ping: {e}");
         } else {

--- a/crates/mumble-protocol/src/state.rs
+++ b/crates/mumble-protocol/src/state.rs
@@ -215,6 +215,24 @@ pub struct ConnectionInfo {
     /// `None` means the server is a standard Mumble server without
     /// Fancy Mumble extensions.
     pub server_fancy_version: Option<u64>,
+    /// The Mumble protocol version announced by the server, in v2
+    /// encoding (`major << 48 | minor << 32 | patch << 16`).
+    /// `None` until the handshake `Version` message is received.
+    pub server_version_v2: Option<u64>,
+}
+
+impl ConnectionInfo {
+    /// Whether the server understands the protobuf UDP audio protocol
+    /// introduced in Mumble 1.5.  Older servers require the legacy
+    /// varint-framed packet format for everything we *send*; inbound
+    /// packets are format-detected, so only the send paths consult this.
+    ///
+    /// Defaults to `true` while the version is still unknown - the
+    /// server announces its version before audio can flow.
+    pub fn supports_protobuf_audio(&self) -> bool {
+        const V1_5_0: u64 = (1 << 48) | (5 << 32);
+        self.server_version_v2.is_none_or(|v| v >= V1_5_0)
+    }
 }
 
 use crate::transport::ocb2::SharedPacketStats;
@@ -348,6 +366,15 @@ impl ServerState {
     /// extensions (`message_id`, `timestamp`, etc.).
     pub fn apply_version(&mut self, version: &crate::proto::mumble_tcp::Version) {
         self.connection.server_fancy_version = version.fancy_version;
+        // Servers < 1.5 only send the legacy v1 encoding; widen it to v2
+        // so a single field can be compared everywhere.
+        self.connection.server_version_v2 = version.version_v2.or_else(|| {
+            version.version_v1.map(|v1| {
+                ((v1 as u64 >> 16) << 48)
+                    | (((v1 as u64 >> 8) & 0xFF) << 32)
+                    | ((v1 as u64 & 0xFF) << 16)
+            })
+        });
     }
 
     /// Apply `ServerSync` to record our session and connection metadata.
@@ -392,6 +419,52 @@ mod tests {
         assert!(state.channels.is_empty());
         assert!(state.own_session().is_none());
         assert!(state.connection.welcome_text.is_none());
+    }
+
+    #[test]
+    fn unknown_server_version_assumes_protobuf_audio() {
+        let state = ServerState::new();
+        assert!(state.connection.supports_protobuf_audio());
+    }
+
+    #[test]
+    fn apply_version_legacy_v1_only_disables_protobuf_audio() {
+        let mut state = ServerState::new();
+        // Mumble 1.3.0 only sends the v1 encoding.
+        let version = mumble_tcp::Version {
+            version_v1: Some((1 << 16) | (3 << 8)),
+            ..Default::default()
+        };
+        state.apply_version(&version);
+        assert!(!state.connection.supports_protobuf_audio());
+        assert_eq!(
+            state.connection.server_version_v2,
+            Some((1 << 48) | (3 << 32))
+        );
+    }
+
+    #[test]
+    fn apply_version_v2_enables_protobuf_audio() {
+        let mut state = ServerState::new();
+        let version = mumble_tcp::Version {
+            version_v1: Some((1 << 16) | (5 << 8)),
+            version_v2: Some((1 << 48) | (5 << 32)),
+            ..Default::default()
+        };
+        state.apply_version(&version);
+        assert!(state.connection.supports_protobuf_audio());
+    }
+
+    #[test]
+    fn apply_version_v1_only_1_5_enables_protobuf_audio() {
+        let mut state = ServerState::new();
+        // A 1.5 server announced only via the widened v1 encoding.
+        let version = mumble_tcp::Version {
+            version_v1: Some((1 << 16) | (5 << 8)),
+            ..Default::default()
+        };
+        state.apply_version(&version);
+        assert!(state.connection.supports_protobuf_audio());
     }
 
     #[test]

--- a/crates/mumble-protocol/src/transport/audio_codec.rs
+++ b/crates/mumble-protocol/src/transport/audio_codec.rs
@@ -330,6 +330,16 @@ impl AudioPacketCodec for ProtobufAudioCodec {
 
 // -- Public API -----------------------------------------------------
 
+/// Encode `audio` for a `UdpTunnel`, choosing the format the server
+/// understands: protobuf v2 for Mumble >= 1.5, legacy Opus otherwise.
+pub fn encode_tunnel_audio(audio: &mumble_udp::Audio, protobuf: bool) -> Vec<u8> {
+    if protobuf {
+        ProtobufAudioCodec::encode(audio)
+    } else {
+        LegacyAudioCodec::encode(audio)
+    }
+}
+
 /// Try to decode a `UdpTunnel` payload as audio.
 ///
 /// Both legacy and protobuf v2 formats share the same header byte

--- a/crates/mumble-protocol/src/transport/udp.rs
+++ b/crates/mumble-protocol/src/transport/udp.rs
@@ -17,7 +17,7 @@ use tracing::{debug, trace, warn};
 use crate::error::{Error, Result};
 use crate::message::UdpMessage;
 use crate::proto::mumble_udp;
-use crate::transport::audio_codec::{AudioPacketCodec, LegacyAudioCodec};
+use crate::transport::audio_codec::{AudioPacketCodec, LegacyAudioCodec, MumbleVarint};
 
 /// Maximum UDP datagram size (Mumble practical limit).
 const MAX_UDP_SIZE: usize = 1024;
@@ -206,6 +206,33 @@ pub fn encode_udp_message(msg: &UdpMessage) -> Vec<u8> {
     }
 }
 
+/// Encode a [`UdpMessage`] in whichever wire format the server understands:
+/// protobuf for Mumble >= 1.5, legacy varint framing otherwise.
+pub fn encode_udp_message_for(msg: &UdpMessage, protobuf: bool) -> Vec<u8> {
+    if protobuf {
+        encode_udp_message(msg)
+    } else {
+        encode_udp_message_legacy(msg)
+    }
+}
+
+/// Encode a [`UdpMessage`] in the legacy wire format used by Mumble < 1.5.
+///
+/// Audio uses the varint-framed Opus encoding; pings are a `0x20` header
+/// byte (`type 1 << 5 | target 0`) followed by the timestamp as a
+/// Mumble varint, which the server echoes back verbatim.
+pub fn encode_udp_message_legacy(msg: &UdpMessage) -> Vec<u8> {
+    match msg {
+        UdpMessage::Audio(audio) => LegacyAudioCodec::encode(audio),
+        UdpMessage::Ping(ping) => {
+            let mut buf = Vec::with_capacity(1 + 9);
+            buf.push(1 << 5); // header: type = Ping (1), target = 0
+            MumbleVarint::write(&mut buf, ping.timestamp);
+            buf
+        }
+    }
+}
+
 /// Decode a raw UDP payload (after decryption) into a [`UdpMessage`].
 ///
 /// Byte 0 is the `UDPMessageType` enum value:
@@ -230,6 +257,14 @@ pub fn decode_udp_message(data: &[u8]) -> Result<UdpMessage> {
         b if b >> 5 == 4 => {
             let audio = LegacyAudioCodec::decode(data)?;
             Ok(UdpMessage::Audio(audio))
+        }
+        // Legacy ping echo (type 1): header byte + varint timestamp.
+        b if b >> 5 == 1 => {
+            let (timestamp, _) = MumbleVarint::read(&data[1..])?;
+            Ok(UdpMessage::Ping(mumble_udp::Ping {
+                timestamp,
+                ..Default::default()
+            }))
         }
         other => Err(Error::InvalidState(format!(
             "unsupported UDP message type: 0x{other:02x}"
@@ -364,6 +399,46 @@ mod tests {
             }
             other => panic!("expected Audio, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn legacy_ping_encode_decode_roundtrip() -> Result<()> {
+        let ping = mumble_udp::Ping {
+            timestamp: 123_456,
+            ..Default::default()
+        };
+        let encoded = encode_udp_message_legacy(&UdpMessage::Ping(ping));
+        assert_eq!(encoded[0], 0x20, "legacy ping header is type 1, target 0");
+
+        let decoded = decode_udp_message(&encoded)?;
+        match decoded {
+            UdpMessage::Ping(p) => assert_eq!(p.timestamp, 123_456),
+            other => panic!("expected Ping, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_audio_encode_uses_opus_header() {
+        let audio = mumble_udp::Audio {
+            frame_number: 9,
+            opus_data: vec![0x01, 0x02],
+            ..Default::default()
+        };
+        let encoded = encode_udp_message_legacy(&UdpMessage::Audio(audio));
+        assert_eq!(encoded[0] >> 5, 4, "legacy audio header is type 4 (Opus)");
+    }
+
+    #[test]
+    fn encode_udp_message_for_switches_format() {
+        let msg = UdpMessage::Audio(mumble_udp::Audio {
+            opus_data: vec![0xAB],
+            ..Default::default()
+        });
+        let protobuf = encode_udp_message_for(&msg, true);
+        assert_eq!(protobuf[0], 0x00, "protobuf audio marker");
+        let legacy = encode_udp_message_for(&msg, false);
+        assert_eq!(legacy[0] >> 5, 4, "legacy Opus header");
     }
 
     #[test]


### PR DESCRIPTION
…s < 1.5.x

## Description

Fixes a Bug where on old Mumble Servers (< 1.5.x) the client was unable to speak with other users due to:
- Client ignored suggested max. bandwith of old servers
- Missing protocol handling for pre 1.5.x Servers

## Changes

<!-- Summarise the key changes. -->

- Bugfix #97 

## Checklist

- [x] Code compiles without warnings (`cargo clippy --workspace -- -D warnings`)
- [x] TypeScript type-checks (`npx tsc --noEmit`)
- [x] Frontend tests pass (`npm test`)
- [x] Rust tests pass (`cargo test --package mumble-protocol --features opus-codec --lib`)
- [x] New functionality has tests
- [ ] Boy Scout Rule applied - files left cleaner than found
