### PR TITLE
Feat/onboarding rework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,17 @@ jobs:
       - name: Install Qt 6
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.11.1'
+          # Pinned to 6.10.3 (newest version aqtinstall can install here).
+          # Qt reorganised the Windows online repository at 6.11.0: the desktop
+          # packages moved from one Updates.xml per version (qt6_<ver>/qt6_<ver>/
+          # Updates.xml) to per-arch subdirs nested under that version dir, e.g.
+          # qt6_6111/qt6_6111_mingw/Updates.xml. aqtinstall 3.3.0 (latest) still
+          # looks for qt6_6111/qt6_6111/Updates.xml (404) -> the install fails
+          # with "Failed to locate XML data for Qt version 6.11.1". Only the
+          # Windows repo migrated, so the Linux job happened to pass on 6.11.1.
+          # Bump back to 6.11.x once aqtinstall supports the new layout.
+          # See crates/qt6ui/README.md.
+          version: '6.10.3'
           arch: ${{ matrix.target.qt-arch }}
           tools: ${{ matrix.target.qt-tools }}
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,15 @@ jobs:
           # platform config files (tauri.linux/windows/macos.conf.json),
           # which Tauri v2 auto-merges. (The old TAURI_CONFIG env var was a
           # Tauri v1 feature and is ignored by Tauri v2.)
+          #
+          # Skip the nested qt6ui build (build.rs -> build_qt6ui). This job
+          # deliberately doesn't install the MinGW Qt kit, so on Windows the
+          # probe only ever emits "qt6ui skipped: Qt MinGW kit not found"
+          # warnings. The minimal Qt client is built and packaged by the
+          # dedicated "Build (Minimal Qt client)" job below, and the full
+          # client bundles only signal-bridge (not qt6ui), so there is
+          # nothing for this build to gain from it.
+          SKIP_QT6UI: "1"
         run: cargo tauri build
 
       - name: Upload build artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,11 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev protobuf-compiler
+          # libglib2.0-dev is listed explicitly (not just via libgtk-3-dev):
+          # cache-apt-pkgs-action only caches/restores the packages named here,
+          # so this transitive dev dep - and its glib-2.0.pc, needed by the
+          # glib-sys build script - goes missing on a cache hit otherwise.
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libgtk-3-dev libglib2.0-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev protobuf-compiler
           version: 1.0
 
       - name: Install protoc (Windows)
@@ -170,7 +174,11 @@ jobs:
         if: runner.os == 'Linux'
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libgtk-3-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev protobuf-compiler
+          # libglib2.0-dev is listed explicitly (not just via libgtk-3-dev):
+          # cache-apt-pkgs-action only caches/restores the packages named here,
+          # so this transitive dev dep - and its glib-2.0.pc, needed by the
+          # glib-sys build script - goes missing on a cache hit otherwise.
+          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libgtk-3-dev libglib2.0-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev protobuf-compiler
           version: 1.0
 
       - name: Install protoc (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,14 @@ jobs:
           # version than the runner's stale apt lists, which aborted the whole
           # install. `apt-get update` first keeps versions current;
           # libglib2.0-dev stays listed explicitly so glib-sys finds its .pc.
+          # libpipewire-0.3-dev provides libpipewire-0.3.pc, which xcap (via
+          # fancy-screenshare) links against on Linux - libspa-sys' build
+          # script panics without it.
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
             libasound2-dev libgtk-3-dev libglib2.0-dev libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev protobuf-compiler
+            libjavascriptcoregtk-4.1-dev protobuf-compiler libpipewire-0.3-dev
 
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
@@ -185,11 +188,14 @@ jobs:
           # version than the runner's stale apt lists, which aborted the whole
           # install. `apt-get update` first keeps versions current;
           # libglib2.0-dev stays listed explicitly so glib-sys finds its .pc.
+          # libpipewire-0.3-dev provides libpipewire-0.3.pc, which xcap (via
+          # fancy-screenshare) links against on Linux - libspa-sys' build
+          # script panics without it.
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
             libasound2-dev libgtk-3-dev libglib2.0-dev libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev protobuf-compiler
+            libjavascriptcoregtk-4.1-dev protobuf-compiler libpipewire-0.3-dev
 
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,14 +77,19 @@ jobs:
       # -- Linux system deps (Tauri + ALSA for cpal) --------------
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          # libglib2.0-dev is listed explicitly (not just via libgtk-3-dev):
-          # cache-apt-pkgs-action only caches/restores the packages named here,
-          # so this transitive dev dep - and its glib-2.0.pc, needed by the
-          # glib-sys build script - goes missing on a cache hit otherwise.
-          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libgtk-3-dev libglib2.0-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev protobuf-compiler
-          version: 1.0
+        run: |
+          # Direct apt install (was awalsh128/cache-apt-pkgs-action). That
+          # action dropped transitive dev deps on a cache hit - glib-2.0.pc
+          # went missing so glib-sys failed - and 404'd on a cache miss once
+          # the mirror rotated a package (e.g. libasound2-dev) to a newer
+          # version than the runner's stale apt lists, which aborted the whole
+          # install. `apt-get update` first keeps versions current;
+          # libglib2.0-dev stays listed explicitly so glib-sys finds its .pc.
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
+            libasound2-dev libgtk-3-dev libglib2.0-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev protobuf-compiler
 
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
@@ -172,14 +177,19 @@ jobs:
 
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          # libglib2.0-dev is listed explicitly (not just via libgtk-3-dev):
-          # cache-apt-pkgs-action only caches/restores the packages named here,
-          # so this transitive dev dep - and its glib-2.0.pc, needed by the
-          # glib-sys build script - goes missing on a cache hit otherwise.
-          packages: libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libasound2-dev libgtk-3-dev libglib2.0-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev protobuf-compiler
-          version: 1.0
+        run: |
+          # Direct apt install (was awalsh128/cache-apt-pkgs-action). That
+          # action dropped transitive dev deps on a cache hit - glib-2.0.pc
+          # went missing so glib-sys failed - and 404'd on a cache miss once
+          # the mirror rotated a package (e.g. libasound2-dev) to a newer
+          # version than the runner's stale apt lists, which aborted the whole
+          # install. `apt-get update` first keeps versions current;
+          # libglib2.0-dev stays listed explicitly so glib-sys finds its .pc.
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
+            libasound2-dev libgtk-3-dev libglib2.0-dev libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev protobuf-compiler
 
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
@@ -269,10 +279,9 @@ jobs:
           cache-dependency-path: crates/mumble-tauri/ui/package-lock.json
 
       - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: protobuf-compiler
-          version: 1.0
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
 
       - name: Install npm dependencies
         working-directory: crates/mumble-tauri/ui
@@ -417,10 +426,10 @@ jobs:
 
       - name: Install Linux system dependencies
         if: runner.os == 'Linux'
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: libasound2-dev protobuf-compiler libgl1-mesa-dev libxkbcommon-dev ninja-build
-          version: 1.0
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libasound2-dev protobuf-compiler libgl1-mesa-dev libxkbcommon-dev ninja-build
 
       - name: Install protoc and ninja (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,12 +191,10 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          TAURI_CONFIG: >-
-            ${{ runner.os == 'Windows'
-                && '{"bundle":{"resources":["signal-bridge/*.dll"]}}'
-                || runner.os == 'macOS'
-                && '{"bundle":{"resources":["signal-bridge/*.dylib"]}}'
-                || '{"bundle":{"resources":["signal-bridge/*.so"]}}' }}
+          # signal-bridge cdylib is bundled via bundle.resources in the
+          # platform config files (tauri.linux/windows/macos.conf.json),
+          # which Tauri v2 auto-merges. (The old TAURI_CONFIG env var was a
+          # Tauri v1 feature and is ignored by Tauri v2.)
         run: cargo tauri build
 
       - name: Upload build artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,22 @@ jobs:
           # client bundles only signal-bridge (not qt6ui), so there is
           # nothing for this build to gain from it.
           SKIP_QT6UI: "1"
-        run: cargo tauri build
+        shell: bash
+        run: |
+          # createUpdaterArtifacts is enabled in tauri.conf.json, so Tauri
+          # signs the bundles for the auto-updater. That needs a valid
+          # TAURI_SIGNING_PRIVATE_KEY. On fork builds the repo secrets are not
+          # exposed, so the key is empty and Tauri aborts with
+          # "failed to decode secret key ... Missing comment in secret key".
+          # When no key is present, disable updater-artifact signing so the
+          # bundle still builds; signed release artifacts are produced only on
+          # the upstream repo where the secret is available.
+          if [ -n "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            cargo tauri build
+          else
+            echo "::warning::No TAURI_SIGNING_PRIVATE_KEY (fork build); building without signed updater artifacts."
+            cargo tauri build --config '{"bundle":{"createUpdaterArtifacts":false}}'
+          fi
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,16 @@ jobs:
           # libpipewire-0.3-dev provides libpipewire-0.3.pc, which xcap (via
           # fancy-screenshare) links against on Linux - libspa-sys' build
           # script panics without it.
+          # libva-dev/libdrm-dev/libgbm-dev back fancy-screenshare's `gpu`
+          # feature (default-on): cros-codecs -> cros-libva does the VA-API
+          # H.264 encode and needs libva.pc; its cros-codecs deps drm/gbm-sys
+          # pkg-config against libdrm/libgbm in turn.
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
             libasound2-dev libgtk-3-dev libglib2.0-dev libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev protobuf-compiler libpipewire-0.3-dev
+            libjavascriptcoregtk-4.1-dev protobuf-compiler libpipewire-0.3-dev \
+            libva-dev libdrm-dev libgbm-dev
 
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
@@ -191,11 +196,16 @@ jobs:
           # libpipewire-0.3-dev provides libpipewire-0.3.pc, which xcap (via
           # fancy-screenshare) links against on Linux - libspa-sys' build
           # script panics without it.
+          # libva-dev/libdrm-dev/libgbm-dev back fancy-screenshare's `gpu`
+          # feature (default-on): cros-codecs -> cros-libva does the VA-API
+          # H.264 encode and needs libva.pc; its cros-codecs deps drm/gbm-sys
+          # pkg-config against libdrm/libgbm in turn.
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf \
             libasound2-dev libgtk-3-dev libglib2.0-dev libsoup-3.0-dev \
-            libjavascriptcoregtk-4.1-dev protobuf-compiler libpipewire-0.3-dev
+            libjavascriptcoregtk-4.1-dev protobuf-compiler libpipewire-0.3-dev \
+            libva-dev libdrm-dev libgbm-dev
 
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'

--- a/crates/fancy-audio-device/Cargo.toml
+++ b/crates/fancy-audio-device/Cargo.toml
@@ -18,11 +18,13 @@ windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Media_Audio",
     "Win32_Media_KernelStreaming",
+    "Win32_Security",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_Threading",
     "Win32_System_Variant",
     "Win32_Devices_FunctionDiscovery",
+    "Win32_UI_Shell_PropertiesSystem",
 ] }
 
 [lints]

--- a/crates/fancy-audio-device/examples/sine_mic.rs
+++ b/crates/fancy-audio-device/examples/sine_mic.rs
@@ -26,6 +26,8 @@ use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use fancy_audio_device as _;
 use mumble_protocol as _;
 use tracing as _;
+// `windows` is a Windows-only dependency; only acknowledge it there.
+#[cfg(target_os = "windows")]
 use windows as _;
 
 struct Args {

--- a/crates/fancy-audio-device/examples/wasapi_probe.rs
+++ b/crates/fancy-audio-device/examples/wasapi_probe.rs
@@ -11,12 +11,34 @@
 //! ```
 //! Pass a device-name substring (default: the default capture device).
 
-#![cfg(target_os = "windows")]
-#![allow(
+// On non-Windows targets (e.g. CI clippy on Linux) the WASAPI probe can't be
+// built, so the crate's dev-deps look unused. Silence that there.
+#![cfg_attr(
+    not(target_os = "windows"),
+    allow(
+        unused_crate_dependencies,
+        reason = "WASAPI probe is Windows-only; its dev-deps are unused elsewhere"
+    )
+)]
+
+// The probe only makes sense on Windows; provide a stub main elsewhere so the
+// example still compiles (and clippy passes) on other platforms.
+#[cfg(not(target_os = "windows"))]
+fn main() {
+    eprintln!("wasapi_probe only runs on Windows (WASAPI).");
+}
+
+#[cfg(target_os = "windows")]
+fn main() {
+    probe::main();
+}
+
+#[cfg(target_os = "windows")]
+#[allow(
     unsafe_code,
     reason = "raw WASAPI COM to mirror the official Mumble client's device open"
 )]
-
+mod probe {
 // The example inherits the crate's deps; acknowledge the ones it doesn't use
 // directly (else `unused_crate_dependencies` fires).
 use cpal as _;
@@ -37,7 +59,7 @@ use windows::Win32::System::Com::{
 use windows::Win32::System::Com::StructuredStorage::PropVariantClear;
 use windows::Win32::Devices::FunctionDiscovery::PKEY_Device_FriendlyName;
 
-fn main() {
+pub fn main() {
     let want = std::env::args().nth(1);
     if want.as_deref() == Some("--users") {
         let users = fancy_audio_device::capture_device_users();
@@ -239,4 +261,5 @@ unsafe fn friendly_name(dev: &IMMDevice) -> Option<String> {
     } else {
         Some(s)
     }
+}
 }

--- a/crates/fancy-audio-device/examples/wasapi_probe.rs
+++ b/crates/fancy-audio-device/examples/wasapi_probe.rs
@@ -59,7 +59,7 @@ use windows::Win32::System::Com::{
 use windows::Win32::System::Com::StructuredStorage::PropVariantClear;
 use windows::Win32::Devices::FunctionDiscovery::PKEY_Device_FriendlyName;
 
-pub fn main() {
+pub(crate) fn main() {
     let want = std::env::args().nth(1);
     if want.as_deref() == Some("--users") {
         let users = fancy_audio_device::capture_device_users();

--- a/crates/fancy-screenshare/examples/camera_probe.rs
+++ b/crates/fancy-screenshare/examples/camera_probe.rs
@@ -25,9 +25,15 @@ use tokio as _;
 use tracing as _;
 use tracing_subscriber as _;
 use webrtc as _;
-use windows as _;
-use windows_core as _;
 use xcap as _;
+// Windows-only deps: only acknowledge them there.
+#[cfg(windows)]
+use windows as _;
+#[cfg(windows)]
+use windows_core as _;
+// Linux GPU-pipeline deps, present only with the default `gpu` feature.
+#[cfg(all(target_os = "linux", feature = "gpu"))]
+use {ashpd as _, cros_codecs as _, libloading as _, pipewire as _};
 
 use fancy_screenshare::{sources, SourceKind};
 

--- a/crates/fancy-screenshare/src/camera.rs
+++ b/crates/fancy-screenshare/src/camera.rs
@@ -80,7 +80,10 @@ pub(crate) const DSHOW_ID_BASE: u32 = 0x1000_0000;
 /// listed once, via its native entry (see [`list_devices`]).
 fn backends() -> Vec<Box<dyn CameraBackend>> {
     // `mut` is only exercised on Windows, where a DirectShow backend is pushed.
-    #[cfg_attr(not(windows), allow(unused_mut))]
+    #[cfg_attr(
+        not(windows),
+        allow(unused_mut, reason = "only the Windows DirectShow push mutates `v`")
+    )]
     let mut v: Vec<Box<dyn CameraBackend>> = vec![Box::new(NativeCameraBackend)];
     #[cfg(windows)]
     v.push(Box::new(crate::camera_directshow::DirectShowBackend));

--- a/crates/fancy-screenshare/src/camera.rs
+++ b/crates/fancy-screenshare/src/camera.rs
@@ -79,6 +79,8 @@ pub(crate) const DSHOW_ID_BASE: u32 = 0x1000_0000;
 /// (native) cameras come first so that a device exposed through *both* APIs is
 /// listed once, via its native entry (see [`list_devices`]).
 fn backends() -> Vec<Box<dyn CameraBackend>> {
+    // `mut` is only exercised on Windows, where a DirectShow backend is pushed.
+    #[cfg_attr(not(windows), allow(unused_mut))]
     let mut v: Vec<Box<dyn CameraBackend>> = vec![Box::new(NativeCameraBackend)];
     #[cfg(windows)]
     v.push(Box::new(crate::camera_directshow::DirectShowBackend));

--- a/crates/fancy-screenshare/src/linux/mod.rs
+++ b/crates/fancy-screenshare/src/linux/mod.rs
@@ -46,7 +46,7 @@ use crate::sources::SourceKind;
 enum EncoderTier {
     Vaapi(vaapi::VaapiEncoder),
     Nvenc(nvenc::NvencEncoder),
-    Cpu(H264Encoder),
+    Cpu(Box<H264Encoder>),
 }
 
 /// Portal + PipeWire capture with VA-API (preferred) or openh264 encode.
@@ -97,7 +97,7 @@ impl GpuPipelineLinux {
                         "screenshare: no GPU encoder (VA-API: {va_err}; NVENC: {nv_err}); \
                          encoding with openh264 instead"
                     );
-                    EncoderTier::Cpu(H264Encoder::new(settings))
+                    EncoderTier::Cpu(Box::new(H264Encoder::new(settings)))
                 }
             },
         };
@@ -142,7 +142,7 @@ impl GpuPipelineLinux {
         );
         let mut cpu = H264Encoder::new(self.settings);
         let encoded = cpu.encode_rgba(w, h, img.as_raw(), true);
-        self.encoder = EncoderTier::Cpu(cpu);
+        self.encoder = EncoderTier::Cpu(Box::new(cpu));
         encoded
     }
 }

--- a/crates/fancy-screenshare/src/linux/nvenc.rs
+++ b/crates/fancy-screenshare/src/linux/nvenc.rs
@@ -130,7 +130,7 @@ const _: () = assert!(size_of::<EncConfig>() == 3584);
 
 /// Byte offsets inside `NV_ENC_CONFIG` (verified against the 12.1 header:
 /// version 0, profileGUID 4, gopLength 20, frameIntervalP 24, then
-/// rcParams at 40 whose prefix is version, rateControlMode, NV_ENC_QP
+/// `rcParams` at 40 whose prefix is version, `rateControlMode`, `NV_ENC_QP`
 /// constQP[12], averageBitRate, maxBitRate).
 mod cfg_off {
     pub(super) const PROFILE_GUID: usize = 4;
@@ -602,6 +602,11 @@ impl NvencEncoder {
         })
     }
 
+    #[allow(
+        clippy::too_many_lines,
+        reason = "one linear NVENC session bring-up (open, buffers, config, init); \
+                  splitting it would scatter the ordered FFI init sequence"
+    )]
     fn create_session(&self, libs: &NvLibs, w: u32, h: u32) -> Result<Session, String> {
         let open = libs
             .fns
@@ -882,6 +887,11 @@ fn guid_bytes(g: Guid) -> [u8; 16] {
 /// `row * pitch`, interleaved UV rows at `pitch * h + row * pitch`), same
 /// BT.601 fixed-point math as the other tiers, threaded in bands of
 /// source-row pairs.
+#[allow(
+    clippy::excessive_nesting,
+    reason = "tight per-pixel BT.601 conversion loops inside a thread scope; \
+              hoisting them out would only obscure the hot inner arithmetic"
+)]
 fn rgba_to_nv12_pitched(
     src_width: usize,
     w: usize,
@@ -893,7 +903,7 @@ fn rgba_to_nv12_pitched(
     let (y_plane, uv_plane) = dst.split_at_mut(pitch * h);
     let pairs = h / 2;
     let threads = std::thread::available_parallelism()
-        .map(|n| n.get())
+        .map(std::num::NonZero::get)
         .unwrap_or(4)
         .min(8);
     let band = pairs.div_ceil(threads.max(1)).max(1);

--- a/crates/fancy-screenshare/src/linux/pipewire_stream.rs
+++ b/crates/fancy-screenshare/src/linux/pipewire_stream.rs
@@ -1,5 +1,5 @@
 //! PipeWire video-stream consumer - the analogue of Chromium's
-//! `SharedScreenCastStream` (modules/desktop_capture/linux/wayland).
+//! `SharedScreenCastStream` (`modules/desktop_capture/linux/wayland`).
 //!
 //! A dedicated thread runs the PipeWire main loop (libwebrtc uses
 //! `pw_thread_loop`; a plain `MainLoop` on our own thread is the same thing
@@ -146,6 +146,11 @@ impl Drop for PwCaptureStream {
 }
 
 /// The loop thread body: connect, negotiate, pump frames until quit/error.
+#[allow(
+    clippy::too_many_lines,
+    reason = "single PipeWire loop lifecycle (connect, negotiate, pump); the \
+              callbacks capture shared loop state and don't factor out cleanly"
+)]
 fn run_loop(
     fd: std::os::fd::OwnedFd,
     node_id: u32,
@@ -290,7 +295,7 @@ fn run_loop(
     Ok(())
 }
 
-/// EnumFormat pod: video/raw, the linear RGB layouts we can swizzle, any
+/// `EnumFormat` pod: video/raw, the linear RGB layouts we can swizzle, any
 /// size, any rate. No `VideoModifier` property = shared-memory buffers.
 fn build_format_pod() -> Result<Vec<u8>, String> {
     let object = pw::spa::pod::object!(

--- a/crates/fancy-screenshare/src/linux/portal.rs
+++ b/crates/fancy-screenshare/src/linux/portal.rs
@@ -64,6 +64,16 @@ impl PortalSession {
         let source_type = match kind {
             SourceKind::Screen => SourceType::Monitor,
             SourceKind::Window => SourceType::Window,
+            // Cameras never reach the ScreenCast portal: create_pipeline()
+            // routes SourceKind::Device to CameraPipeline (nokhwa/V4L2) before
+            // this is called. Guard the invariant so a mis-route fails loudly
+            // instead of opening a screen-capture dialog for a webcam.
+            SourceKind::Device => {
+                return Err(
+                    "cameras are captured via the camera pipeline, not the screencast portal"
+                        .to_string(),
+                );
+            }
         };
 
         let (session, node_id, size, fd) = rt

--- a/crates/fancy-screenshare/src/linux/portal.rs
+++ b/crates/fancy-screenshare/src/linux/portal.rs
@@ -1,5 +1,5 @@
-//! xdg-desktop-portal ScreenCast session - the Linux analogue of Chromium's
-//! `ScreenCastPortal` (modules/desktop_capture/linux/wayland).
+//! xdg-desktop-portal `ScreenCast` session - the Linux analogue of Chromium's
+//! `ScreenCastPortal` (`modules/desktop_capture/linux/wayland`).
 //!
 //! The portal is the only capture entry point Wayland permits, and modern
 //! Chromium prefers it on X11 sessions too. The D-Bus dance is:

--- a/crates/fancy-screenshare/src/linux/vaapi.rs
+++ b/crates/fancy-screenshare/src/linux/vaapi.rs
@@ -1,4 +1,4 @@
-//! VA-API H.264 encoding through cros-codecs - the ChromeOS media team's
+//! VA-API H.264 encoding through cros-codecs - the `ChromeOS` media team's
 //! encoder stack, i.e. the same lineage as Chromium's
 //! `VaapiVideoEncodeAccelerator` (and the crate Discord forks for its Linux
 //! client).
@@ -410,7 +410,7 @@ fn rgba_to_nv12(src_width: usize, w: usize, h: usize, rgba: &[u8], out: &mut Vec
 
     let pairs = h / 2;
     let threads = std::thread::available_parallelism()
-        .map(|n| n.get())
+        .map(std::num::NonZero::get)
         .unwrap_or(4)
         .min(8);
     let band = pairs.div_ceil(threads.max(1)).max(1);

--- a/crates/mumble-tauri/src/commands/mod.rs
+++ b/crates/mumble-tauri/src/commands/mod.rs
@@ -29,8 +29,6 @@ pub(crate) mod realtime;
 /// Screen sharing needs OS capture APIs unavailable on Android.
 #[cfg(not(target_os = "android"))]
 pub(crate) mod screenshare;
-/// The red "you are sharing" bar pinned to the shared screen/window.
-#[cfg(not(target_os = "android"))]
 pub(crate) mod server;
 pub(crate) mod servers;
 pub(crate) mod system;

--- a/crates/mumble-tauri/src/state/pchat/signal_bridge.rs
+++ b/crates/mumble-tauri/src/state/pchat/signal_bridge.rs
@@ -55,6 +55,14 @@ pub(crate) fn load_signal_bridge(
                 dir.join("../lib/fancy-mumble/signal-bridge")
                     .join(lib_name),
             );
+            // Tauri's Linux .deb/AppImage install bundled resources under the
+            // PRODUCT name from tauri.conf.json (productName = "FancyMumble"),
+            // which is case-sensitive and differs from the /usr/bin binary
+            // name (mumble-tauri). The resource lands at
+            // /usr/lib/FancyMumble/signal-bridge/<lib>, so the /usr/bin binary
+            // resolves it via ../lib/FancyMumble/signal-bridge/.
+            candidates.push(dir.join("../lib/FancyMumble/signal-bridge").join(lib_name));
+            candidates.push(dir.join("../lib/FancyMumble").join(lib_name));
         }
     }
 

--- a/crates/mumble-tauri/src/ui_mode.rs
+++ b/crates/mumble-tauri/src/ui_mode.rs
@@ -299,7 +299,6 @@ fn total_memory_mb() -> u64 {
         .and_then(|s| {
             s.lines().find_map(|l| {
                 l.strip_prefix("MemTotal:")?
-                    .trim()
                     .split_whitespace()
                     .next()?
                     .parse::<u64>()

--- a/crates/mumble-tauri/src/updater/mod.rs
+++ b/crates/mumble-tauri/src/updater/mod.rs
@@ -85,8 +85,15 @@ fn spawn_startup_check(app: tauri::AppHandle) {
         // `updater_set_auto_install` and `updater_set_skipped_version`
         // preferences before we open the window.
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-        match commands::run_check(&app).await {
-            Ok(true) => {
+        // Bound the update check: it hits GitHub over HTTPS, and on a slow,
+        // captive or offline network `updater.check()` can hang indefinitely.
+        // The main window is `visible: false` and is only revealed after this
+        // returns, so an unbounded check would leave the app (and the
+        // onboarding flow) permanently invisible. Always fall through to
+        // showing the window.
+        const STARTUP_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
+        match tokio::time::timeout(STARTUP_CHECK_TIMEOUT, commands::run_check(&app)).await {
+            Ok(Ok(true)) => {
                 let auto = app
                     .try_state::<UpdaterState>()
                     .map(|s| s.auto_install())
@@ -96,12 +103,19 @@ fn spawn_startup_check(app: tauri::AppHandle) {
                     show_main_window(&app);
                 }
             }
-            Ok(false) => {
+            Ok(Ok(false)) => {
                 tracing::debug!("Updater: no update available");
                 show_main_window(&app);
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 tracing::info!("Updater: startup check failed: {e}");
+                show_main_window(&app);
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "Updater: startup check timed out after {}s; showing main window",
+                    STARTUP_CHECK_TIMEOUT.as_secs()
+                );
                 show_main_window(&app);
             }
         }

--- a/crates/mumble-tauri/tauri.linux.conf.json
+++ b/crates/mumble-tauri/tauri.linux.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "resources": ["signal-bridge/*.so"]
+  }
+}

--- a/crates/mumble-tauri/tauri.macos.conf.json
+++ b/crates/mumble-tauri/tauri.macos.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "resources": ["signal-bridge/*.dylib"]
+  }
+}

--- a/crates/mumble-tauri/tauri.windows.conf.json
+++ b/crates/mumble-tauri/tauri.windows.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "resources": ["signal-bridge/*.dll"]
+  }
+}

--- a/crates/mumble-tauri/ui/src/components/onboarding/OnboardingAdminPanel.module.css
+++ b/crates/mumble-tauri/ui/src/components/onboarding/OnboardingAdminPanel.module.css
@@ -1,154 +1,360 @@
+/* --- Server onboarding admin editor ----------------------------- */
+
 .panel {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 16px;
-  max-width: 860px;
+  max-width: 720px;
+}
+
+.pageHead {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.pageIcon {
+  color: var(--color-accent);
+  margin-top: 2px;
+  flex: 0 0 auto;
 }
 
 .heading {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
+  font-size: 17px;
+  font-weight: 650;
 }
 
 .subtle {
-  margin: 0;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--color-text-secondary);
+  line-height: 1.5;
+  margin-top: 3px;
 }
 
-.row {
+.tag {
+  margin-left: auto;
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+  border-radius: 999px;
+  padding: 4px 10px;
+  white-space: nowrap;
+}
+
+/* --- Cards ------------------------------------------------------ */
+
+.card,
+.questionCard {
   display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius-lg);
+}
+
+.questionCard {
   gap: 12px;
-  align-items: center;
-}
-
-.row label {
-  font-size: 13px;
-}
-
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  flex: 1;
-}
-
-.fieldLabel {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--color-text-secondary);
-}
-
-.input,
-.textarea {
-  background: var(--color-glass-hover);
-  border: 1px solid var(--color-glass-border);
-  border-radius: var(--radius-sm);
-  padding: 8px 10px;
-  color: inherit;
-  font: inherit;
-  font-size: 13px;
-}
-
-.textarea {
-  resize: vertical;
-  min-height: 60px;
-}
-
-.questionCard,
-.answerCard {
-  border: 1px solid var(--color-glass-border);
-  border-radius: var(--radius-md, 8px);
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  background: var(--color-glass-hover);
-}
-
-.answerCard {
-  background: var(--color-bg-primary);
 }
 
 .cardHeader {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  gap: 10px;
+}
+
+.cardBadge {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-on-accent, #fff);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-hover));
 }
 
 .cardTitle {
-  margin: 0;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
 }
 
-.tag {
-  font-size: 11px;
-  padding: 2px 6px;
+.grow {
+  flex: 1;
+}
+
+/* --- Fields ----------------------------------------------------- */
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+}
+
+.row .field {
+  flex: 1;
+}
+
+.fieldLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.fieldLabel svg {
+  color: var(--color-text-muted);
+}
+
+.input,
+.textarea {
+  width: 100%;
+  padding: 10px 12px;
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-primary);
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 46px;
+}
+
+.input::placeholder,
+.textarea::placeholder {
+  color: var(--color-text-muted);
+}
+
+.input:focus,
+.textarea:focus {
+  border-color: var(--color-accent);
+  background: var(--color-glass-hover);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+}
+
+.emojiInput {
+  width: 52px;
+  flex: 0 0 auto;
+  text-align: center;
+  font-size: 18px;
+  padding: 8px 4px;
+}
+
+/* --- Toggle switch ---------------------------------------------- */
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggleInput {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggleTrack {
+  position: relative;
+  flex: 0 0 auto;
+  width: 38px;
+  height: 22px;
   border-radius: 999px;
   background: var(--color-glass-border);
+  transition: background 0.18s ease;
+}
+
+.toggleThumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  transition: transform 0.18s ease;
+}
+
+.toggleInput:checked + .toggleTrack {
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-hover));
+}
+
+.toggleInput:checked + .toggleTrack .toggleThumb {
+  transform: translateX(16px);
+}
+
+.toggleInput:focus-visible + .toggleTrack {
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+}
+
+.toggleText {
+  display: flex;
+  flex-direction: column;
+}
+
+.toggleLabel {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.toggleHint {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.toggleRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 22px;
+  padding: 4px 0;
+}
+
+/* --- Answers ---------------------------------------------------- */
+
+.answers {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-left: 12px;
+  border-left: 2px solid var(--color-glass-border);
+}
+
+.answerCard {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--color-glass-hover);
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius-md);
+}
+
+.answerTop {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* --- Buttons ---------------------------------------------------- */
+
+.iconBtn {
+  display: inline-grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.iconBtn:hover:not(:disabled) {
+  background: var(--color-danger-soft, rgba(239, 68, 68, 0.12));
+  color: var(--color-danger);
+}
+
+.iconBtn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.ghostBtn,
+.addQuestionBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 9px 14px;
+  background: var(--color-glass);
+  border: 1px dashed var(--color-glass-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.ghostBtn:hover,
+.addQuestionBtn:hover {
+  background: var(--color-glass-hover);
+  color: var(--color-text-primary);
+  border-color: var(--color-accent);
+}
+
+.addQuestionBtn {
+  align-self: flex-start;
 }
 
 .actions {
   display: flex;
-  gap: 8px;
   justify-content: flex-end;
-  align-items: center;
+  padding-top: 4px;
 }
 
-.btn {
-  appearance: none;
-  -webkit-appearance: none;
-  padding: 6px 12px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-glass-border);
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  font-size: 12px;
+.saveBtn {
+  padding: 11px 22px;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-hover));
+  border: none;
+  border-radius: var(--radius-md);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.12s;
+  transition: opacity 0.2s, box-shadow 0.2s, transform 0.1s;
+  box-shadow: 0 4px 16px var(--color-accent-glow);
 }
 
-.btn:hover:not(:disabled) {
-  background: var(--color-glass-hover);
+.saveBtn:hover:not(:disabled) {
+  opacity: 0.92;
+  box-shadow: 0 6px 24px var(--color-accent-glow);
 }
 
-.btn:disabled {
+.saveBtn:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.saveBtn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.btnPrimary {
-  border: none;
-  background: var(--color-accent);
-  color: #fff;
-  font-weight: 600;
-}
-
-.btnDanger {
-  color: var(--color-danger);
-}
-
 .error {
-  padding: 8px 12px;
-  border-radius: var(--radius-sm);
-  background: var(--color-danger-bg, rgba(255, 80, 80, 0.1));
+  padding: 10px 12px;
+  background: var(--color-danger-soft, rgba(239, 68, 68, 0.12));
+  border: 1px solid var(--color-danger);
+  border-radius: var(--radius-md);
   color: var(--color-danger);
-  font-size: 12px;
+  font-size: 13px;
 }
 
-.checkboxRow {
-  display: flex;
-  gap: 16px;
-  flex-wrap: wrap;
-  font-size: 12px;
-}
-
-.spacer {
-  flex: 1;
+@media (max-width: 560px) {
+  .row {
+    flex-direction: column;
+  }
 }

--- a/crates/mumble-tauri/ui/src/components/onboarding/OnboardingAdminPanel.tsx
+++ b/crates/mumble-tauri/ui/src/components/onboarding/OnboardingAdminPanel.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useAppStore } from "../../store";
@@ -7,18 +7,15 @@ import type {
   OnboardingConfig,
   OnboardingQuestion,
 } from "../../types";
+import { Autocomplete, type AutocompleteOption } from "../elements/Autocomplete";
+import { PlusIcon, TrashIcon, HashIcon, SparklesIcon } from "../../icons";
 import { isOnboardingSupported, useOnboardingStore } from "./onboardingStore";
 import styles from "./OnboardingAdminPanel.module.css";
 
 const MAX_QUESTIONS = 5;
 
 function emptyAnswer(): OnboardingAnswer {
-  return {
-    id: crypto.randomUUID(),
-    label: "",
-    channel_ids: [],
-    group_names: [],
-  };
+  return { id: crypto.randomUUID(), label: "", channel_ids: [], group_names: [] };
 }
 
 function emptyQuestion(): OnboardingQuestion {
@@ -33,22 +30,7 @@ function emptyQuestion(): OnboardingQuestion {
 }
 
 function emptyConfig(): OnboardingConfig {
-  return {
-    version: 1,
-    enabled: false,
-    default_channel_ids: [],
-    questions: [emptyQuestion()],
-    revision: 0,
-  };
-}
-
-function parseIdList(raw: string): number[] {
-  return raw
-    .split(/[\s,]+/)
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .map((s) => Number(s))
-    .filter((n) => Number.isInteger(n) && n >= 0);
+  return { version: 1, enabled: false, default_channel_ids: [], questions: [emptyQuestion()], revision: 0 };
 }
 
 function parseStringList(raw: string): string[] {
@@ -58,10 +40,35 @@ function parseStringList(raw: string): string[] {
     .filter(Boolean);
 }
 
+/** A labelled on/off switch that matches the app's design system. */
+function Toggle({
+  checked,
+  onChange,
+  label,
+  hint,
+}: Readonly<{ checked: boolean; onChange: (v: boolean) => void; label: string; hint?: string }>) {
+  return (
+    <label className={styles.toggle}>
+      <input
+        type="checkbox"
+        className={styles.toggleInput}
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <span className={styles.toggleTrack} aria-hidden="true">
+        <span className={styles.toggleThumb} />
+      </span>
+      <span className={styles.toggleText}>
+        <span className={styles.toggleLabel}>{label}</span>
+        {hint ? <span className={styles.toggleHint}>{hint}</span> : null}
+      </span>
+    </label>
+  );
+}
+
 /**
- * Admin editor for the onboarding workflow.  Pre-populates from the
- * server-broadcast config and persists changes via
- * `save_onboarding_config`.
+ * Admin editor for the server onboarding workflow.  Pre-populates from the
+ * server-broadcast config and persists changes via `save_onboarding_config`.
  */
 export default function OnboardingAdminPanel() {
   const remote = useOnboardingStore((s) => s.config);
@@ -74,9 +81,7 @@ export default function OnboardingAdminPanel() {
   const supported = isOnboardingSupported(serverFancyVersion);
   const { t } = useTranslation("settings");
 
-  const [draft, setDraft] = useState<OnboardingConfig>(
-    () => remote ?? emptyConfig(),
-  );
+  const [draft, setDraft] = useState<OnboardingConfig>(() => remote ?? emptyConfig());
 
   // Re-seed when the server pushes a new revision so we don't overwrite a
   // newer admin's edit.
@@ -84,73 +89,58 @@ export default function OnboardingAdminPanel() {
     if (remote) setDraft(remote);
   }, [remote]);
 
-  const updateQuestion = (idx: number, patch: Partial<OnboardingQuestion>) => {
-    setDraft((d) => ({
-      ...d,
-      questions: d.questions.map((q, i) => (i === idx ? { ...q, ...patch } : q)),
-    }));
-  };
+  // Channel picker: real names instead of raw numeric IDs.
+  const channelOptions = useMemo<readonly AutocompleteOption<number>[]>(
+    () => channels.map((c) => ({ key: c.id, label: `# ${c.name}`, value: c.id })),
+    [channels],
+  );
+  const optionById = useMemo(() => {
+    const m = new Map<number, AutocompleteOption<number>>();
+    for (const o of channelOptions) m.set(o.value, o);
+    return m;
+  }, [channelOptions]);
+  const toOptions = (ids: number[]): AutocompleteOption<number>[] =>
+    ids.map((id) => optionById.get(id) ?? { key: id, label: `#${id}`, value: id });
 
-  const updateAnswer = (
-    qIdx: number,
-    aIdx: number,
-    patch: Partial<OnboardingAnswer>,
-  ) => {
+  const updateQuestion = (idx: number, patch: Partial<OnboardingQuestion>) =>
+    setDraft((d) => ({ ...d, questions: d.questions.map((q, i) => (i === idx ? { ...q, ...patch } : q)) }));
+
+  const updateAnswer = (qIdx: number, aIdx: number, patch: Partial<OnboardingAnswer>) =>
     setDraft((d) => ({
       ...d,
-      questions: d.questions.map((q, i) => {
-        if (i !== qIdx) return q;
-        return {
-          ...q,
-          answers: q.answers.map((a, j) =>
-            j === aIdx ? { ...a, ...patch } : a,
-          ),
-        };
-      }),
+      questions: d.questions.map((q, i) =>
+        i !== qIdx ? q : { ...q, answers: q.answers.map((a, j) => (j === aIdx ? { ...a, ...patch } : a)) },
+      ),
     }));
-  };
 
   const addQuestion = () =>
     setDraft((d) =>
-      d.questions.length >= MAX_QUESTIONS
-        ? d
-        : { ...d, questions: [...d.questions, emptyQuestion()] },
+      d.questions.length >= MAX_QUESTIONS ? d : { ...d, questions: [...d.questions, emptyQuestion()] },
     );
 
   const removeQuestion = (idx: number) =>
-    setDraft((d) => ({
-      ...d,
-      questions: d.questions.filter((_, i) => i !== idx),
-    }));
+    setDraft((d) => ({ ...d, questions: d.questions.filter((_, i) => i !== idx) }));
 
   const addAnswer = (qIdx: number) =>
     setDraft((d) => ({
       ...d,
-      questions: d.questions.map((q, i) =>
-        i === qIdx ? { ...q, answers: [...q.answers, emptyAnswer()] } : q,
-      ),
+      questions: d.questions.map((q, i) => (i === qIdx ? { ...q, answers: [...q.answers, emptyAnswer()] } : q)),
     }));
 
   const removeAnswer = (qIdx: number, aIdx: number) =>
     setDraft((d) => ({
       ...d,
       questions: d.questions.map((q, i) =>
-        i === qIdx
-          ? { ...q, answers: q.answers.filter((_, j) => j !== aIdx) }
-          : q,
+        i === qIdx ? { ...q, answers: q.answers.filter((_, j) => j !== aIdx) } : q,
       ),
     }));
 
   const handleSave = () => {
-    // Drop questions/answers without a label/text so we never save UI placeholders.
     const sanitized: OnboardingConfig = {
       ...draft,
       questions: draft.questions
         .filter((q) => q.text.trim().length > 0)
-        .map((q) => ({
-          ...q,
-          answers: q.answers.filter((a) => a.label.trim().length > 0),
-        }))
+        .map((q) => ({ ...q, answers: q.answers.filter((a) => a.label.trim().length > 0) }))
         .filter((q) => q.answers.length > 0),
     };
     saveConfig(sanitized).catch(() => {});
@@ -159,65 +149,64 @@ export default function OnboardingAdminPanel() {
   if (!supported) {
     return (
       <div className={styles.panel}>
-        <h3 className={styles.heading}>{t("onboarding.admin.heading")}</h3>
-        <p className={styles.subtle}>
-          {t("onboarding.admin.unsupportedServer")}
-        </p>
+        <header className={styles.pageHead}>
+          <SparklesIcon className={styles.pageIcon} width={20} height={20} />
+          <h3 className={styles.heading}>{t("onboarding.admin.heading")}</h3>
+        </header>
+        <p className={styles.subtle}>{t("onboarding.admin.unsupportedServer")}</p>
       </div>
     );
   }
 
   return (
     <div className={styles.panel}>
-      <h3 className={styles.heading}>{t("onboarding.admin.heading")}</h3>
-      <p className={styles.subtle}>
-        {t("onboarding.admin.description")} {t("onboarding.admin.maxQuestionsHint", { max: MAX_QUESTIONS })}
-      </p>
+      <header className={styles.pageHead}>
+        <SparklesIcon className={styles.pageIcon} width={20} height={20} />
+        <div>
+          <h3 className={styles.heading}>{t("onboarding.admin.heading")}</h3>
+          <p className={styles.subtle}>
+            {t("onboarding.admin.description")}{" "}
+            {t("onboarding.admin.maxQuestionsHint", { max: MAX_QUESTIONS })}
+          </p>
+        </div>
+        <span className={styles.tag}>{t("onboarding.admin.revisionTag", { n: draft.revision, m: channels.length })}</span>
+      </header>
 
-      <div className={styles.checkboxRow}>
-        <label>
-          <input
-            type="checkbox"
-            checked={draft.enabled}
-            onChange={(e) =>
-              setDraft({ ...draft, enabled: e.target.checked })
-            }
-          />{" "}
-          {t("onboarding.admin.enabledLabel")}
-        </label>
-        <span className={styles.spacer} />
-        <span className={styles.tag}>
-          {t("onboarding.admin.revisionTag", { n: draft.revision, m: channels.length })}
-        </span>
-      </div>
-
-      <div className={styles.field}>
-        <label className={styles.fieldLabel}>
-          {t("onboarding.admin.defaultChannelIdsLabel")}
-        </label>
-        <input
-          className={styles.input}
-          value={draft.default_channel_ids.join(", ")}
-          onChange={(e) =>
-            setDraft({
-              ...draft,
-              default_channel_ids: parseIdList(e.target.value),
-            })
-          }
-          placeholder="0, 1"
+      <div className={styles.card}>
+        <Toggle
+          checked={draft.enabled}
+          onChange={(v) => setDraft({ ...draft, enabled: v })}
+          label={t("onboarding.admin.enabledLabel")}
         />
+        <div className={styles.field}>
+          <label className={styles.fieldLabel}>
+            <HashIcon width={13} height={13} /> {t("onboarding.admin.defaultChannelIdsLabel")}
+          </label>
+          <Autocomplete
+            multiple
+            options={channelOptions}
+            value={toOptions(draft.default_channel_ids)}
+            onChange={(opts) => setDraft({ ...draft, default_channel_ids: opts.map((o) => o.value) })}
+            placeholder={t("onboarding.admin.defaultChannelIdsLabel")}
+            noOptionsText={t("onboarding.admin.noChannels", { defaultValue: "No channels" })}
+          />
+        </div>
       </div>
 
       {draft.questions.map((q, qIdx) => (
-        <div key={q.id} className={styles.questionCard}>
+        <section key={q.id} className={styles.questionCard}>
           <div className={styles.cardHeader}>
+            <span className={styles.cardBadge}>{qIdx + 1}</span>
             <p className={styles.cardTitle}>{t("onboarding.admin.questionTitle", { n: qIdx + 1 })}</p>
+            <span className={styles.grow} />
             <button
-              className={`${styles.btn} ${styles.btnDanger}`}
+              className={styles.iconBtn}
               onClick={() => removeQuestion(qIdx)}
               disabled={draft.questions.length <= 1}
+              aria-label={t("onboarding.admin.deleteBtn")}
+              title={t("onboarding.admin.deleteBtn")}
             >
-              {t("onboarding.admin.deleteBtn")}
+              <TrashIcon width={15} height={15} />
             </button>
           </div>
 
@@ -231,142 +220,109 @@ export default function OnboardingAdminPanel() {
             />
           </div>
 
-          <div className={styles.checkboxRow}>
-            <label>
-              <input
-                type="checkbox"
-                checked={q.multi_select}
-                onChange={(e) =>
-                  updateQuestion(qIdx, { multi_select: e.target.checked })
-                }
-              />{" "}
-              {t("onboarding.admin.multiSelectLabel")}
-            </label>
-            <label>
-              <input
-                type="checkbox"
-                checked={q.required}
-                onChange={(e) =>
-                  updateQuestion(qIdx, { required: e.target.checked })
-                }
-              />{" "}
-              {t("onboarding.admin.requiredLabel")}
-            </label>
-            <label>
-              <input
-                type="checkbox"
-                checked={q.ask_before_join}
-                onChange={(e) =>
-                  updateQuestion(qIdx, { ask_before_join: e.target.checked })
-                }
-              />{" "}
-              {t("onboarding.admin.askBeforeJoinLabel")}
-            </label>
+          <div className={styles.toggleRow}>
+            <Toggle
+              checked={q.multi_select}
+              onChange={(v) => updateQuestion(qIdx, { multi_select: v })}
+              label={t("onboarding.admin.multiSelectLabel")}
+            />
+            <Toggle
+              checked={q.required}
+              onChange={(v) => updateQuestion(qIdx, { required: v })}
+              label={t("onboarding.admin.requiredLabel")}
+            />
+            <Toggle
+              checked={q.ask_before_join}
+              onChange={(v) => updateQuestion(qIdx, { ask_before_join: v })}
+              label={t("onboarding.admin.askBeforeJoinLabel")}
+            />
           </div>
 
-          {q.answers.map((a, aIdx) => (
-            <div key={a.id} className={styles.answerCard}>
-              <div className={styles.cardHeader}>
-                <p className={styles.cardTitle}>{t("onboarding.admin.answerTitle", { n: aIdx + 1 })}</p>
-                <button
-                  className={`${styles.btn} ${styles.btnDanger}`}
-                  onClick={() => removeAnswer(qIdx, aIdx)}
-                  disabled={q.answers.length <= 1}
-                >
-                  {t("onboarding.admin.deleteBtn")}
-                </button>
-              </div>
-              <div className={styles.row}>
-                <div className={styles.field}>
-                  <label className={styles.fieldLabel}>{t("onboarding.admin.answerLabelField")}</label>
+          <div className={styles.answers}>
+            {q.answers.map((a, aIdx) => (
+              <div key={a.id} className={styles.answerCard}>
+                <div className={styles.answerTop}>
                   <input
-                    className={styles.input}
-                    value={a.label}
-                    onChange={(e) =>
-                      updateAnswer(qIdx, aIdx, { label: e.target.value })
-                    }
-                    placeholder="Gaming"
-                  />
-                </div>
-                <div className={styles.field}>
-                  <label className={styles.fieldLabel}>{t("onboarding.admin.emojiLabel")}</label>
-                  <input
-                    className={styles.input}
+                    className={`${styles.input} ${styles.emojiInput}`}
                     value={a.emoji ?? ""}
-                    onChange={(e) =>
-                      updateAnswer(qIdx, aIdx, {
-                        emoji: e.target.value || undefined,
-                      })
-                    }
+                    onChange={(e) => updateAnswer(qIdx, aIdx, { emoji: e.target.value || undefined })}
                     maxLength={4}
+                    placeholder="🙂"
+                    aria-label={t("onboarding.admin.emojiLabel")}
+                  />
+                  <input
+                    className={`${styles.input} ${styles.grow}`}
+                    value={a.label}
+                    onChange={(e) => updateAnswer(qIdx, aIdx, { label: e.target.value })}
+                    placeholder={t("onboarding.admin.answerLabelField")}
+                    aria-label={t("onboarding.admin.answerLabelField")}
+                  />
+                  <button
+                    className={styles.iconBtn}
+                    onClick={() => removeAnswer(qIdx, aIdx)}
+                    disabled={q.answers.length <= 1}
+                    aria-label={t("onboarding.admin.deleteBtn")}
+                    title={t("onboarding.admin.deleteBtn")}
+                  >
+                    <TrashIcon width={14} height={14} />
+                  </button>
+                </div>
+
+                <div className={styles.field}>
+                  <label className={styles.fieldLabel}>
+                    <HashIcon width={13} height={13} /> {t("onboarding.admin.channelIdsLabel")}
+                  </label>
+                  <Autocomplete
+                    multiple
+                    options={channelOptions}
+                    value={toOptions(a.channel_ids)}
+                    onChange={(opts) => updateAnswer(qIdx, aIdx, { channel_ids: opts.map((o) => o.value) })}
+                    placeholder={t("onboarding.admin.channelIdsLabel")}
+                    noOptionsText={t("onboarding.admin.noChannels", { defaultValue: "No channels" })}
+                  />
+                </div>
+
+                <div className={styles.row}>
+                  <div className={styles.field}>
+                    <label className={styles.fieldLabel}>{t("onboarding.admin.aclGroupNamesLabel")}</label>
+                    <input
+                      className={styles.input}
+                      value={a.group_names.join(", ")}
+                      onChange={(e) => updateAnswer(qIdx, aIdx, { group_names: parseStringList(e.target.value) })}
+                      placeholder="gamers, newcomer"
+                    />
+                  </div>
+                </div>
+
+                <div className={styles.field}>
+                  <label className={styles.fieldLabel}>{t("onboarding.admin.descriptionLabel")}</label>
+                  <textarea
+                    className={styles.textarea}
+                    value={a.description ?? ""}
+                    onChange={(e) => updateAnswer(qIdx, aIdx, { description: e.target.value || undefined })}
+                    rows={2}
                   />
                 </div>
               </div>
-              <div className={styles.field}>
-                <label className={styles.fieldLabel}>
-                  {t("onboarding.admin.channelIdsLabel")}
-                </label>
-                <input
-                  className={styles.input}
-                  value={a.channel_ids.join(", ")}
-                  onChange={(e) =>
-                    updateAnswer(qIdx, aIdx, {
-                      channel_ids: parseIdList(e.target.value),
-                    })
-                  }
-                  placeholder="5, 6"
-                />
-              </div>
-              <div className={styles.field}>
-                <label className={styles.fieldLabel}>
-                  {t("onboarding.admin.aclGroupNamesLabel")}
-                </label>
-                <input
-                  className={styles.input}
-                  value={a.group_names.join(", ")}
-                  onChange={(e) =>
-                    updateAnswer(qIdx, aIdx, {
-                      group_names: parseStringList(e.target.value),
-                    })
-                  }
-                  placeholder="gamers, newcomer"
-                />
-              </div>
-              <div className={styles.field}>
-                  <label className={styles.fieldLabel}>{t("onboarding.admin.descriptionLabel")}</label>
-                <textarea
-                  className={styles.textarea}
-                  value={a.description ?? ""}
-                  onChange={(e) =>
-                    updateAnswer(qIdx, aIdx, {
-                      description: e.target.value || undefined,
-                    })
-                  }
-                />
-              </div>
-            </div>
-          ))}
+            ))}
 
-          <button className={styles.btn} onClick={() => addAnswer(qIdx)}>
-            {t("onboarding.admin.addAnswerBtn")}
-          </button>
-        </div>
+            <button className={styles.ghostBtn} onClick={() => addAnswer(qIdx)}>
+              <PlusIcon width={15} height={15} /> {t("onboarding.admin.addAnswerBtn")}
+            </button>
+          </div>
+        </section>
       ))}
 
       {draft.questions.length < MAX_QUESTIONS ? (
-        <button className={styles.btn} onClick={addQuestion}>
-          {t("onboarding.admin.addQuestionBtn")}
+        <button className={styles.addQuestionBtn} onClick={addQuestion}>
+          <PlusIcon width={16} height={16} /> {t("onboarding.admin.addQuestionBtn")}
         </button>
       ) : null}
 
       {error ? <div className={styles.error}>{error}</div> : null}
 
       <div className={styles.actions}>
-        <button
-          className={`${styles.btn} ${styles.btnPrimary}`}
-          onClick={handleSave}
-          disabled={busy}
-        >
+        <button className={styles.saveBtn} onClick={handleSave} disabled={busy}>
           {busy ? t("onboarding.admin.savingBtn") : t("onboarding.admin.saveBroadcastBtn")}
         </button>
       </div>

--- a/crates/mumble-tauri/ui/src/components/onboarding/OnboardingModal.module.css
+++ b/crates/mumble-tauri/ui/src/components/onboarding/OnboardingModal.module.css
@@ -1,104 +1,127 @@
+/* --- Server onboarding modal (shown to members on join) --------- */
+
 .dialog {
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-glass-border);
-  border-radius: var(--radius-lg, 12px);
-  width: 560px;
-  max-width: 92vw;
-  max-height: 88vh;
+  width: min(480px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
   display: flex;
   flex-direction: column;
-  animation: scaleIn 0.12s ease-out;
-  overflow: hidden;
+  gap: 18px;
+  padding: 26px 26px 20px;
+  background: var(--color-bg-elevated, var(--color-surface));
+  -webkit-backdrop-filter: var(--glass-blur);
+  backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
 }
 
-@keyframes scaleIn {
-  from { transform: scale(0.96); opacity: 0; }
-  to { transform: scale(1); opacity: 1; }
-}
+/* --- Header ----------------------------------------------------- */
 
 .header {
-  padding: 20px 24px 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 6px 12px;
+}
+
+.headerIcon {
+  grid-row: span 2;
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-md);
+  color: #fff;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-hover));
+  box-shadow: 0 4px 14px var(--color-accent-glow);
 }
 
 .title {
-  margin: 0 0 4px;
   font-size: 18px;
-  font-weight: 600;
+  font-weight: 650;
+  line-height: 1.25;
 }
 
 .subtitle {
-  margin: 0;
+  grid-column: 2;
   font-size: 13px;
   color: var(--color-text-secondary);
 }
 
+/* --- Progress --------------------------------------------------- */
+
 .progress {
-  display: flex;
-  gap: 4px;
-  padding: 12px 24px 0;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: 6px;
 }
 
 .progressStep {
-  flex: 1;
-  height: 3px;
+  height: 4px;
   border-radius: 999px;
   background: var(--color-glass-border);
+  transition: background 0.25s ease;
 }
 
 .progressStepActive {
-  background: var(--color-accent);
+  background: linear-gradient(90deg, var(--color-accent), var(--color-accent-hover));
 }
+
+/* --- Body ------------------------------------------------------- */
 
 .body {
-  flex: 1;
   overflow-y: auto;
-  padding: 16px 24px 8px;
-}
-
-.questionText {
-  margin: 0 0 8px;
-  font-size: 15px;
-  font-weight: 600;
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .questionMeta {
-  margin: 0 0 16px;
   font-size: 12px;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
 }
 
+/* --- Answers ---------------------------------------------------- */
+
 .answers {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 8px;
 }
 
 .answer {
-  appearance: none;
-  -webkit-appearance: none;
   display: flex;
+  align-items: center;
   gap: 12px;
-  align-items: flex-start;
+  width: 100%;
+  padding: 13px 14px;
   text-align: left;
-  padding: 12px 14px;
-  border-radius: var(--radius-md, 8px);
+  background: var(--color-glass);
   border: 1px solid var(--color-glass-border);
-  background: transparent;
-  color: inherit;
-  font: inherit;
+  border-radius: var(--radius-md);
+  color: var(--color-text-primary);
   cursor: pointer;
-  transition: background 0.12s, border-color 0.12s;
+  transition: border-color 0.15s, background 0.15s, transform 0.08s;
 }
 
 .answer:hover {
   background: var(--color-glass-hover);
 }
 
+.answer:active {
+  transform: scale(0.995);
+}
+
 .answerSelected {
   border-color: var(--color-accent);
-  background: var(--color-glass-hover);
+  background: var(--color-accent-soft);
+  box-shadow: 0 0 0 1px var(--color-accent);
 }
 
 .answerEmoji {
+  flex: 0 0 auto;
   font-size: 22px;
   line-height: 1;
 }
@@ -108,11 +131,12 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  min-width: 0;
 }
 
 .answerLabel {
-  font-weight: 600;
   font-size: 14px;
+  font-weight: 600;
 }
 
 .answerDesc {
@@ -122,61 +146,69 @@
 }
 
 .checkmark {
-  width: 18px;
-  height: 18px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
   border-radius: 50%;
   border: 1.5px solid var(--color-glass-border);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  margin-top: 2px;
-  font-size: 11px;
-  color: #fff;
+  color: transparent;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
 
 .checkmarkSelected {
-  border-color: var(--color-accent);
   background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
 }
 
+/* --- Default channels preview ----------------------------------- */
+
 .defaultChannels {
-  margin: 8px 24px;
-  padding: 12px 14px;
-  border-radius: var(--radius-md, 8px);
-  border: 1px dashed var(--color-glass-border);
-  background: var(--color-glass-hover);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .defaultChannelsTitle {
-  margin: 0 0 6px;
-  font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+  font-size: 13px;
   color: var(--color-text-secondary);
 }
 
 .defaultChannelsList {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 8px;
 }
 
 .defaultChannelChip {
-  font-size: 12px;
-  padding: 3px 8px;
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  background: var(--color-glass-hover);
+  border: 1px solid var(--color-glass-border);
   border-radius: 999px;
-  background: var(--color-glass-border);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+/* --- Footer ----------------------------------------------------- */
+
+.error {
+  padding: 9px 12px;
+  background: var(--color-danger-soft, rgba(239, 68, 68, 0.12));
+  border: 1px solid var(--color-danger);
+  border-radius: var(--radius-md);
+  color: var(--color-danger);
+  font-size: 13px;
 }
 
 .actions {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 8px;
-  padding: 14px 24px 18px;
-  border-top: 1px solid var(--color-glass-border);
+  gap: 10px;
 }
 
 .spacer {
@@ -184,45 +216,36 @@
 }
 
 .btn {
-  appearance: none;
-  -webkit-appearance: none;
-  padding: 8px 16px;
-  border-radius: var(--radius-sm);
+  padding: 10px 18px;
+  background: var(--color-glass);
   border: 1px solid var(--color-glass-border);
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  font-size: 13px;
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  font-weight: 500;
   cursor: pointer;
-  transition: background 0.12s;
+  transition: background 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
 }
 
 .btn:hover:not(:disabled) {
   background: var(--color-glass-hover);
+  color: var(--color-text-primary);
 }
 
 .btn:disabled {
-  cursor: not-allowed;
   opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .btnPrimary {
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-hover));
   border: none;
-  background: var(--color-accent);
   color: #fff;
-  font-weight: 600;
+  box-shadow: 0 4px 16px var(--color-accent-glow);
 }
 
 .btnPrimary:hover:not(:disabled) {
-  opacity: 0.85;
-  background: var(--color-accent);
-}
-
-.error {
-  margin: 8px 24px 0;
-  padding: 8px 12px;
-  border-radius: var(--radius-sm);
-  background: var(--color-danger-bg, rgba(255, 80, 80, 0.1));
-  color: var(--color-danger);
-  font-size: 12px;
+  opacity: 0.92;
+  color: #fff;
+  box-shadow: 0 6px 24px var(--color-accent-glow);
 }

--- a/crates/mumble-tauri/ui/src/components/onboarding/OnboardingModal.tsx
+++ b/crates/mumble-tauri/ui/src/components/onboarding/OnboardingModal.tsx
@@ -1,4 +1,4 @@
-﻿import { CheckIcon } from "../../icons";
+﻿import { CheckIcon, SparklesIcon } from "../../icons";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -122,6 +122,9 @@ export default function OnboardingModal() {
         aria-labelledby="onboarding-title"
       >
         <div className={styles.header}>
+          <span className={styles.headerIcon} aria-hidden="true">
+            <SparklesIcon width={18} height={18} />
+          </span>
           <h2 id="onboarding-title" className={styles.title}>
             {isPreview ? t("onboarding.modal.welcomeTitle") : question?.text}
           </h2>

--- a/crates/mumble-tauri/ui/src/locales/en/server.json
+++ b/crates/mumble-tauri/ui/src/locales/en/server.json
@@ -293,5 +293,34 @@
     "advancedHint": "Full control"
   },
   "submit": "Get started",
-  "submitting": "Starting..."
+  "submitting": "Starting...",
+  "onboarding": {
+    "subtitle": "Let's set up Fancy Mumble in a few quick steps.",
+    "stepOf": "Step {{current}} of {{total}}",
+    "next": "Next",
+    "back": "Back",
+    "finish": "Get started",
+    "steps": {
+      "identity": "Identity",
+      "interface": "Interface",
+      "appearance": "Appearance",
+      "ready": "All set"
+    },
+    "identity": {
+      "title": "What should we call you?",
+      "hint": "This is the name others see. You can use a different name per server later."
+    },
+    "interface": {
+      "title": "Choose your interface",
+      "hint": "You can switch anytime in Settings."
+    },
+    "appearance": {
+      "title": "Pick a theme",
+      "hint": "Make it yours — plenty more in Settings."
+    },
+    "ready": {
+      "title": "You're all set, {{name}}!",
+      "hint": "Jump in and connect to your first server."
+    }
+  }
 }

--- a/crates/mumble-tauri/ui/src/pages/WelcomePage.module.css
+++ b/crates/mumble-tauri/ui/src/pages/WelcomePage.module.css
@@ -1,4 +1,4 @@
-/* --- Welcome / Onboarding Page ----------------------------------- */
+/* --- Welcome / Onboarding wizard -------------------------------- */
 
 .page {
   display: flex;
@@ -14,57 +14,147 @@
 
 .card {
   width: 100%;
-  max-width: 360px;
-  padding: 32px 28px;
+  max-width: 520px;
+  padding: 28px 30px 24px;
   background: var(--color-glass);
   -webkit-backdrop-filter: var(--glass-blur);
   backdrop-filter: var(--glass-blur);
   border: 1px solid var(--color-glass-border);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
 }
 
-/* --- Logo ------------------------------------------------------- */
+/* --- Header ----------------------------------------------------- */
 
-.logo {
-  text-align: center;
-  margin-bottom: 24px;
+.header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
 }
 
 .logoIcon {
-  margin: 0 auto 12px;
+  flex: 0 0 auto;
 }
 
 .title {
   font-size: 20px;
-  font-weight: 600;
+  font-weight: 650;
   letter-spacing: -0.01em;
+  line-height: 1.2;
 }
 
-/* --- Form fields ------------------------------------------------ */
-
-.field {
-  margin-bottom: 20px;
-}
-
-.label {
-  display: block;
+.subtitle {
   font-size: 13px;
-  font-weight: 500;
-  margin-bottom: 8px;
   color: var(--color-text-secondary);
+  margin-top: 3px;
 }
+
+/* --- Stepper ---------------------------------------------------- */
+
+.stepper {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: 8px;
+}
+
+.stepDot {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stepBar {
+  height: 4px;
+  border-radius: 999px;
+  background: var(--color-glass-border);
+  transition: background 0.25s ease;
+}
+
+.stepLabel {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  letter-spacing: 0.01em;
+  transition: color 0.25s ease;
+}
+
+.stepDone .stepBar {
+  background: var(--color-accent-hover);
+}
+
+.stepCurrent .stepBar {
+  background: linear-gradient(90deg, var(--color-accent), var(--color-accent-hover));
+  box-shadow: 0 0 10px var(--color-accent-glow);
+}
+
+.stepCurrent .stepLabel {
+  color: var(--color-text-primary);
+}
+
+/* --- Body / steps ----------------------------------------------- */
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.step {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 210px;
+  animation: fade 0.25s ease;
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.stepHead {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.stepIcon {
+  color: var(--color-accent);
+}
+
+.stepTitle {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.hint {
+  font-size: 12.5px;
+  color: var(--color-text-muted);
+  line-height: 1.45;
+}
+
+/* --- Inputs ----------------------------------------------------- */
 
 .input {
   width: 100%;
-  padding: 12px 16px;
+  padding: 13px 16px;
   background: var(--color-glass);
   border: 1px solid var(--color-glass-border);
   border-radius: var(--radius-md);
   color: var(--color-text-primary);
   font-size: 15px;
   outline: none;
-  transition: border-color 0.2s, background 0.2s;
+  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
 }
 
 .input::placeholder {
@@ -74,49 +164,143 @@
 .input:focus {
   border-color: var(--color-accent);
   background: var(--color-glass-hover);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
-.actionRow {
+/* --- Theme grid ------------------------------------------------- */
+
+.themeGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+
+.themeCard {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 7px;
+  padding: 8px;
+  background: var(--color-glass);
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, transform 0.1s;
+}
+
+.themeCard:hover {
+  background: var(--color-glass-hover);
+  transform: translateY(-1px);
+}
+
+.themeActive {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 1px var(--color-accent), 0 4px 14px var(--color-accent-glow);
+}
+
+.swatches {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px;
+  height: 34px;
+  border-radius: 7px;
+  overflow: hidden;
+}
+
+.swatch {
+  width: 100%;
+  height: 100%;
+}
+
+.themeLabel {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.themeActive .themeLabel {
+  color: var(--color-text-primary);
+}
+
+.themeCheck {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  color: #fff;
+  background: var(--color-accent);
+  border-radius: 999px;
+  padding: 2px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+
+/* --- Ready step ------------------------------------------------- */
+
+.ready {
+  align-items: center;
+  text-align: center;
+  justify-content: center;
+}
+
+.readyLogo {
+  margin-bottom: 4px;
+}
+
+.readyTitle {
+  font-size: 19px;
+  font-weight: 650;
+}
+
+.summary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.summaryChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--color-glass-hover);
+  border: 1px solid var(--color-glass-border);
+  border-radius: 999px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.summaryChip svg {
+  color: var(--color-accent);
+}
+
+/* --- Footer / actions ------------------------------------------ */
+
+.footer {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 12px;
 }
 
-.actionRow .button {
-  flex: 1;
-}
-
-.backLink {
-  background: none;
-  border: none;
-  color: var(--color-accent);
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  padding: 4px 8px;
-  border-radius: var(--radius-sm);
-  white-space: nowrap;
-  transition: background 0.15s;
-}
-
-.backLink:hover {
-  background: var(--color-glass-hover);
-}
-
-/* --- Continue button -------------------------------------------- */
-
 .button {
-  width: 100%;
-  padding: 12px;
+  min-width: 148px;
+  padding: 12px 20px;
   background: linear-gradient(135deg, var(--color-accent), var(--color-accent-hover));
   border: none;
   border-radius: var(--radius-md);
-  color: white;
-  font-size: 15px;
+  color: #fff;
+  font-size: 14.5px;
   font-weight: 600;
   cursor: pointer;
   transition: opacity 0.2s, transform 0.1s, box-shadow 0.2s;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
@@ -124,7 +308,7 @@
 }
 
 .button:hover:not(:disabled) {
-  opacity: 0.9;
+  opacity: 0.92;
   box-shadow: 0 6px 24px var(--color-accent-glow);
 }
 
@@ -136,51 +320,34 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
-/* --- Mode toggle ------------------------------------------------ */
 
-.modeToggle {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0;
-  background: rgba(0, 0, 0, 0.18);
-  border-radius: var(--radius-md);
-  padding: 3px;
-}
-
-.modeOption {
-  display: flex;
-  flex-direction: column;
+.ghostButton {
+  display: inline-flex;
   align-items: center;
-  gap: 2px;
-  padding: 10px 8px;
+  gap: 6px;
+  padding: 11px 16px;
   background: transparent;
-  border: none;
-  border-radius: calc(var(--radius-md) - 2px);
-  cursor: pointer;
-  transition: background 0.18s, box-shadow 0.18s;
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius-md);
   color: var(--color-text-secondary);
-  line-height: 1;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
-.modeOption:hover:not(.modeActive) {
-  background: var(--color-glass-subtle);
+.ghostButton:hover:not(:disabled) {
+  background: var(--color-glass-hover);
   color: var(--color-text-primary);
 }
 
-.modeActive {
-  background: var(--color-glass-active);
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.25);
-  color: var(--color-text-primary);
+.ghostButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
-.modeTitle {
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
-
-.modeHint {
-  font-size: 11px;
-  color: inherit;
-  opacity: 0.65;
+@media (max-width: 560px) {
+  .themeGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }

--- a/crates/mumble-tauri/ui/src/pages/WelcomePage.tsx
+++ b/crates/mumble-tauri/ui/src/pages/WelcomePage.tsx
@@ -1,15 +1,28 @@
-﻿import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { invoke } from "@tauri-apps/api/core";
 import { completeSetup } from "../preferencesStorage";
+import {
+  loadPersonalization,
+  savePersonalization,
+  type PersonalizationData,
+} from "../personalizationStorage";
+import { THEMES, applyTheme, getCurrentTheme, type ThemeId } from "../themes";
+import { RadioCardGroup, type RadioCardOption } from "../components/elements/RadioCardGroup";
 import BrandLogo from "../components/elements/BrandLogo";
-import type { UserMode } from "../types";
-// Hardware floors for the minimal-mode suggestion: the WebView-based full
-// UI needs a few hundred MB, so on very small machines the native qt6ui
-// client (~60-105 MB) is the better default. Values come from the repo-root
-// constants.json (single source of truth, generated at build time).
+import {
+  UserIcon,
+  SparklesIcon,
+  SlidersIcon,
+  PaletteIcon,
+  CheckIcon,
+  ChevronLeftIcon,
+  ArrowRightIcon,
+} from "../icons";
+// Hardware floors for the minimal-mode suggestion (repo-root constants.json).
 import { WEAK_PC_MAX_MEMORY_MB, WEAK_PC_MAX_CPU_CORES } from "../utils/appConstants";
+import type { UserMode } from "../types";
 import styles from "./WelcomePage.module.css";
 
 interface SystemSpecs {
@@ -17,16 +30,33 @@ interface SystemSpecs {
   cpu_cores: number;
 }
 
+const STEPS = ["identity", "interface", "appearance", "ready"] as const;
+type StepId = (typeof STEPS)[number];
+
 export default function WelcomePage({ onComplete }: Readonly<{ onComplete?: () => void }>) {
   const { t } = useTranslation("server");
   const navigate = useNavigate();
+
+  const [stepIndex, setStepIndex] = useState(0);
   const [mode, setMode] = useState<UserMode>("normal");
   const [username, setUsername] = useState("");
+  const [theme, setTheme] = useState<ThemeId>(getCurrentTheme());
   const [saving, setSaving] = useState(false);
+  // Remember the persisted personalization so we only patch `theme` on finish.
+  const personalizationRef = useRef<PersonalizationData | null>(null);
 
-  // First-run weak-PC check: WelcomePage only renders on the very first
-  // startup, so this prompt appears at most once. Choosing "minimal"
-  // persists the marker and hands off to the qt6ui client immediately.
+  const step: StepId = STEPS[stepIndex];
+  const isLast = stepIndex === STEPS.length - 1;
+  const canProceed = step !== "identity" || username.trim().length > 0;
+
+  useEffect(() => {
+    void loadPersonalization().then((p) => {
+      personalizationRef.current = p;
+      setTheme(p.theme);
+    });
+  }, []);
+
+  // First-run weak-PC check: offer the lightweight native qt6ui client.
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -46,7 +76,6 @@ export default function WelcomePage({ onComplete }: Readonly<{ onComplete?: () =
         await invoke("set_ui_mode", { mode: "minimal" });
         await invoke("relaunch_in_minimal_mode");
       } catch (e) {
-        // Non-fatal: specs unavailable or qt6ui missing - stay in full mode.
         console.warn("weak-PC minimal-mode prompt skipped:", e);
         await invoke("set_ui_mode", { mode: "full" }).catch(() => undefined);
       }
@@ -56,86 +85,188 @@ export default function WelcomePage({ onComplete }: Readonly<{ onComplete?: () =
     };
   }, [t]);
 
-  const handleSubmit = useCallback(
-    async (e: { preventDefault: () => void }) => {
-      e.preventDefault();
-      if (!username.trim()) return;
-      setSaving(true);
+  const pickTheme = useCallback((id: ThemeId) => {
+    setTheme(id);
+    applyTheme(id); // live preview
+  }, []);
+
+  const finish = useCallback(async () => {
+    if (!username.trim() || saving) return;
+    setSaving(true);
+    try {
+      const base = personalizationRef.current ?? (await loadPersonalization());
+      await savePersonalization({ ...base, theme });
       await completeSetup(mode, username.trim());
-      // Generate a default certificate for TLS client auth.
+      // Generate a default certificate for TLS client auth (non-fatal).
       try {
         await invoke("generate_certificate", { label: "default" });
       } catch {
-        // Non-fatal - the user can still connect anonymously.
+        /* user can still connect anonymously */
       }
+    } finally {
       onComplete?.();
       navigate("/", { replace: true });
-    },
-    [mode, username, navigate, onComplete],
-  );
+    }
+  }, [username, saving, theme, mode, onComplete, navigate]);
+
+  const goNext = useCallback(() => {
+    if (!canProceed) return;
+    if (isLast) void finish();
+    else setStepIndex((i) => Math.min(i + 1, STEPS.length - 1));
+  }, [canProceed, isLast, finish]);
+
+  const goBack = useCallback(() => setStepIndex((i) => Math.max(i - 1, 0)), []);
+
+  const modeOptions: readonly RadioCardOption<UserMode>[] = [
+    { value: "normal", label: t("mode.simple"), description: t("mode.simpleHint"), Icon: SparklesIcon },
+    { value: "expert", label: t("mode.advanced"), description: t("mode.advancedHint"), Icon: SlidersIcon },
+  ];
+
+  const activeThemeLabel = THEMES.find((th) => th.id === theme)?.label ?? theme;
+  const activeModeLabel = mode === "normal" ? t("mode.simple") : t("mode.advanced");
 
   return (
     <div className={styles.page}>
       <div className={styles.card}>
-        {/* Logo */}
-        <div className={styles.logo}>
-          <BrandLogo size={52} className={styles.logoIcon} />
-          <h1 className={styles.title}>{t("title")}</h1>
+        <header className={styles.header}>
+          <BrandLogo size={44} className={styles.logoIcon} />
+          <div>
+            <h1 className={styles.title}>{t("title")}</h1>
+            <p className={styles.subtitle}>{t("onboarding.subtitle")}</p>
+          </div>
+        </header>
+
+        {/* Stepper */}
+        <div className={styles.stepper} aria-hidden="true">
+          {STEPS.map((s, i) => (
+            <span
+              key={s}
+              className={`${styles.stepDot} ${i === stepIndex ? styles.stepCurrent : ""} ${
+                i < stepIndex ? styles.stepDone : ""
+              }`}
+            >
+              <span className={styles.stepBar} />
+              <span className={styles.stepLabel}>{t(`onboarding.steps.${s}`)}</span>
+            </span>
+          ))}
         </div>
 
-        <form onSubmit={handleSubmit}>
-          {/* Username */}
-          <div className={styles.field}>
-            <label htmlFor="welcome-username" className={styles.label}>
-              {t("username")}
-            </label>
-            <input
-              id="welcome-username"
-              className={styles.input}
-              type="text"
-              placeholder={t("usernamePlaceholder")}
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              autoFocus
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              spellCheck={false}
-            />
-          </div>
+        <form
+          className={styles.body}
+          onSubmit={(e) => {
+            e.preventDefault();
+            goNext();
+          }}
+        >
+          {step === "identity" && (
+            <section className={styles.step}>
+              <div className={styles.stepHead}>
+                <UserIcon className={styles.stepIcon} width={18} height={18} />
+                <h2 className={styles.stepTitle}>{t("onboarding.identity.title")}</h2>
+              </div>
+              <input
+                id="welcome-username"
+                className={styles.input}
+                type="text"
+                placeholder={t("usernamePlaceholder")}
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                // eslint-disable-next-line jsx-a11y/no-autofocus
+                autoFocus
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                maxLength={64}
+              />
+              <p className={styles.hint}>{t("onboarding.identity.hint")}</p>
+            </section>
+          )}
 
-          {/* Mode selection */}
-          <div className={styles.field}>
-            <span className={styles.label}>{t("interface")}</span>
-            <div className={styles.modeToggle} role="radiogroup">
-              <button
-                type="button"
-                className={`${styles.modeOption} ${mode === "normal" ? styles.modeActive : ""}`}
-                onClick={() => setMode("normal")}
-                aria-pressed={mode === "normal"}
-              >
-                <span className={styles.modeTitle}>{t("mode.simple")}</span>
-                <span className={styles.modeHint}>{t("mode.simpleHint")}</span>
-              </button>
-              <button
-                type="button"
-                className={`${styles.modeOption} ${mode === "expert" ? styles.modeActive : ""}`}
-                onClick={() => setMode("expert")}
-                aria-pressed={mode === "expert"}
-              >
-                <span className={styles.modeTitle}>{t("mode.advanced")}</span>
-                <span className={styles.modeHint}>{t("mode.advancedHint")}</span>
-              </button>
-            </div>
-          </div>
+          {step === "interface" && (
+            <section className={styles.step}>
+              <div className={styles.stepHead}>
+                <SlidersIcon className={styles.stepIcon} width={18} height={18} />
+                <h2 className={styles.stepTitle}>{t("onboarding.interface.title")}</h2>
+              </div>
+              <RadioCardGroup name="ui-mode" options={modeOptions} value={mode} onChange={setMode} />
+              <p className={styles.hint}>{t("onboarding.interface.hint")}</p>
+            </section>
+          )}
 
-          <button
-            className={styles.button}
-            type="submit"
-            disabled={!username.trim() || saving}
-          >
-            {saving ? t("submitting") : t("submit")}
-          </button>
+          {step === "appearance" && (
+            <section className={styles.step}>
+              <div className={styles.stepHead}>
+                <PaletteIcon className={styles.stepIcon} width={18} height={18} />
+                <h2 className={styles.stepTitle}>{t("onboarding.appearance.title")}</h2>
+              </div>
+              <div className={styles.themeGrid} role="radiogroup" aria-label={t("onboarding.appearance.title")}>
+                {THEMES.map((th) => {
+                  const active = th.id === theme;
+                  return (
+                    <button
+                      key={th.id}
+                      type="button"
+                      className={`${styles.themeCard} ${active ? styles.themeActive : ""}`}
+                      onClick={() => pickTheme(th.id)}
+                      aria-pressed={active}
+                    >
+                      <span className={styles.swatches}>
+                        {th.swatches.map((c, i) => (
+                          <span key={i} className={styles.swatch} style={{ background: c }} />
+                        ))}
+                      </span>
+                      <span className={styles.themeLabel}>{th.label}</span>
+                      {active && <CheckIcon className={styles.themeCheck} width={13} height={13} />}
+                    </button>
+                  );
+                })}
+              </div>
+              <p className={styles.hint}>{t("onboarding.appearance.hint")}</p>
+            </section>
+          )}
+
+          {step === "ready" && (
+            <section className={`${styles.step} ${styles.ready}`}>
+              <BrandLogo size={64} className={styles.readyLogo} />
+              <h2 className={styles.readyTitle}>{t("onboarding.ready.title", { name: username.trim() })}</h2>
+              <p className={styles.hint}>{t("onboarding.ready.hint")}</p>
+              <div className={styles.summary}>
+                <span className={styles.summaryChip}>
+                  <UserIcon width={14} height={14} /> {username.trim()}
+                </span>
+                <span className={styles.summaryChip}>
+                  <SlidersIcon width={14} height={14} /> {activeModeLabel}
+                </span>
+                <span className={styles.summaryChip}>
+                  <PaletteIcon width={14} height={14} /> {activeThemeLabel}
+                </span>
+              </div>
+            </section>
+          )}
+
+          <footer className={styles.footer}>
+            {stepIndex > 0 ? (
+              <button type="button" className={styles.ghostButton} onClick={goBack} disabled={saving}>
+                <ChevronLeftIcon width={16} height={16} /> {t("onboarding.back")}
+              </button>
+            ) : (
+              <span />
+            )}
+            <button className={styles.button} type="submit" disabled={!canProceed || saving}>
+              {isLast ? (
+                <>
+                  {saving ? t("submitting") : t("onboarding.finish")}
+                  {!saving && <CheckIcon width={16} height={16} />}
+                </>
+              ) : (
+                <>
+                  {t("onboarding.next")}
+                  <ArrowRightIcon width={16} height={16} />
+                </>
+              )}
+            </button>
+          </footer>
         </form>
       </div>
     </div>

--- a/crates/qt6ui/README.md
+++ b/crates/qt6ui/README.md
@@ -139,6 +139,24 @@ on `PATH` or run `windeployqt` against `target\release\qt6ui.exe`.
 
 Logging: set `RUST_LOG` (e.g. `RUST_LOG=qt6ui=debug,mumble_protocol=info`).
 
+## CI note: Qt version pin
+
+The Windows CI job (`.github/workflows/ci.yml`) installs Qt with
+`jurplel/install-qt-action`, which drives `aqtinstall`. Qt reorganised its
+Windows online repository at **6.11.0**: the desktop packages moved from a
+single `Updates.xml` per version (`qt6_<ver>/qt6_<ver>/Updates.xml`) to
+per-arch subdirs nested under the version dir
+(`qt6_6111/qt6_6111_mingw/Updates.xml`, `.../qt6_6111_msvc2022_64/…`, …).
+`aqtinstall` 3.3.0 (latest) still looks for the old
+`qt6_6111/qt6_6111/Updates.xml` (404) and fails with *"Failed to locate XML
+data for Qt version 6.11.1"*. Only the Windows repo migrated, so the Linux Qt
+job still passes on 6.11.x.
+
+CI is therefore **pinned to 6.10.3** — the newest version served under the old
+layout that still provides the `win64_mingw` kit + `tools_mingw1310`. Local dev
+installs (via Qt's own maintenance tool / offline installer) are unaffected and
+can use 6.11.x. Bump the CI pin back once `aqtinstall` gains new-layout support.
+
 ## License
 
 This crate — **and only this crate** — is licensed **LGPL-3.0-or-later**


### PR DESCRIPTION
## Description

<img width="1024" height="768" alt="grafik" src="https://github.com/user-attachments/assets/9b184dcc-440c-458e-b2ee-8f4310d21eb1" />
<img width="1024" height="768" alt="grafik" src="https://github.com/user-attachments/assets/16f7e1a2-49ac-4c4c-98d5-94ce8f1f9680" />
<img width="1024" height="768" alt="grafik" src="https://github.com/user-attachments/assets/a07f62dd-e3d7-41d5-bbc6-ecfd9660d641" />
<img width="1024" height="768" alt="grafik" src="https://github.com/user-attachments/assets/e92ed04c-25b8-4947-b2ad-42b134f63601" />


Reworks the onboarding experience and fixes two build/packaging regressions found along the way.

- **First-run onboarding** was a single cramped card that rolled its own inputs, offered only username + interface mode, and could fail to appear on startup at all (the main window is only revealed after a no-timeout GitHub update check).
- **Server onboarding questionnaire** (admin editor + join modal) looked dated and bypassed the shared component library — most painfully, admins had to type raw numeric channel IDs.
- While building, the freshly-added camera code didn't compile on Linux, and the AGPL `signal-bridge` cdylib was never actually shipped in installers.

No related issue.

## Changes

- **Onboarding (first run):** rebuilt `WelcomePage` as a 4-step wizard (Identity → Interface → Appearance → All set) with a progress stepper and summary; uses the shared `RadioCardGroup` and design-system tokens instead of hand-rolled controls. Adds an appearance step with all 11 themes (swatches + live preview) persisted via `personalizationStorage`.
- **Startup visibility fix:** the main window ships `visible:false` and was revealed only after the updater's `run_check()` — which hits GitHub over HTTPS with no timeout and could hang forever. Bounded it with a 6s timeout that always falls through to `show_main_window()`.
- **Onboarding (server questionnaire):** restyled the admin editor from design tokens (numbered cards, toggle switches, dashed add-buttons, gradient save) and replaced the raw comma-separated numeric channel-ID inputs with the shared `Autocomplete` so channels are picked by name. Restyled the join `Modal` to match the first-run wizard.
- **`fix(signal-bridge)`:** declare `bundle.resources` in `tauri.{linux,windows,macos}.conf.json` (Tauri v2 auto-merges these) instead of the dead `TAURI_CONFIG` env var, and add the productName-cased `/usr/lib/FancyMumble/…` candidate to `load_signal_bridge` so installed builds find the library. Verified on a real release `.deb` and the Windows `.dll` under Wine.
- **`fix(screenshare)`:** handle the new `SourceKind::Device` in the Linux ScreenCast portal match (cameras route to `CameraPipeline`, not the portal), fixing an `E0004` that broke all Linux release builds.

## Checklist

- [x] Code compiles without warnings (`cargo clippy --workspace -- -D warnings`)
- [x] TypeScript type-checks (`npx tsc --noEmit`)
- [x] Frontend tests pass (`npm test`)
- [ ] Rust tests pass (`cargo test --package mumble-protocol --features opus-codec --lib`)
- [ ] New functionality has tests
- [x] Boy Scout Rule applied - files left cleaner than found