### PR TITLE
Feat/admin panel fixes

### DIFF
--- a/crates/mumble-tauri/src/commands/audio.rs
+++ b/crates/mumble-tauri/src/commands/audio.rs
@@ -6,9 +6,22 @@ use crate::state::{self, AppState, AudioDevice, AudioSettings, VoiceState};
 
 /// List available audio input devices (microphones).
 /// Only available on desktop (cpal is not supported on Android).
+///
+/// Runs the enumeration on the blocking pool: WASAPI/COM device enumeration
+/// takes tens of milliseconds, and the Settings page fires this (plus
+/// [`get_output_devices`]) on every mount. Done inline it ties up runtime
+/// workers the protocol event loop needs, which starves `mixer.feed()` and
+/// surfaces as bursts of "dropped oldest samples" playback glitches.
 #[cfg(not(target_os = "android"))]
 #[tauri::command]
-pub(crate) fn get_audio_devices() -> Vec<AudioDevice> {
+pub(crate) async fn get_audio_devices() -> Vec<AudioDevice> {
+    tauri::async_runtime::spawn_blocking(enumerate_input_devices)
+        .await
+        .unwrap_or_default()
+}
+
+#[cfg(not(target_os = "android"))]
+fn enumerate_input_devices() -> Vec<AudioDevice> {
     use cpal::traits::{DeviceTrait, HostTrait};
 
     let host = cpal::default_host();
@@ -41,15 +54,24 @@ pub(crate) fn get_audio_devices() -> Vec<AudioDevice> {
 /// Stub: on Android, return an empty device list.
 #[cfg(target_os = "android")]
 #[tauri::command]
-pub(crate) fn get_audio_devices() -> Vec<AudioDevice> {
+pub(crate) async fn get_audio_devices() -> Vec<AudioDevice> {
     Vec::new()
 }
 
 /// List available audio output devices (speakers/headphones).
 /// Only available on desktop (cpal is not supported on Android).
+///
+/// Blocking-pool for the same reason as [`get_audio_devices`].
 #[cfg(not(target_os = "android"))]
 #[tauri::command]
-pub(crate) fn get_output_devices() -> Vec<AudioDevice> {
+pub(crate) async fn get_output_devices() -> Vec<AudioDevice> {
+    tauri::async_runtime::spawn_blocking(enumerate_output_devices)
+        .await
+        .unwrap_or_default()
+}
+
+#[cfg(not(target_os = "android"))]
+fn enumerate_output_devices() -> Vec<AudioDevice> {
     use cpal::traits::{DeviceTrait, HostTrait};
 
     let host = cpal::default_host();
@@ -82,7 +104,7 @@ pub(crate) fn get_output_devices() -> Vec<AudioDevice> {
 /// Stub: on Android, return an empty device list.
 #[cfg(target_os = "android")]
 #[tauri::command]
-pub(crate) fn get_output_devices() -> Vec<AudioDevice> {
+pub(crate) async fn get_output_devices() -> Vec<AudioDevice> {
     Vec::new()
 }
 

--- a/crates/mumble-tauri/src/commands/certificates.rs
+++ b/crates/mumble-tauri/src/commands/certificates.rs
@@ -16,10 +16,18 @@ pub(crate) async fn generate_certificate(
 }
 
 /// List the labels of all identities stored in `{app_data_dir}/identities/`.
+///
+/// The directory scan runs on the blocking pool: Settings fires this on
+/// every mount, and synchronous fs I/O on a runtime worker delays the
+/// protocol event loop (audio glitches - see `get_audio_devices`).
 #[tauri::command]
 pub(crate) async fn list_certificates(app: tauri::AppHandle) -> Result<Vec<String>, String> {
     let data_dir = crate::e2e_data_dir(&app)?;
-    Ok(state::pchat::IdentityStore::new(data_dir).list_labels())
+    tauri::async_runtime::spawn_blocking(move || {
+        state::pchat::IdentityStore::new(data_dir).list_labels()
+    })
+    .await
+    .map_err(|e| e.to_string())
 }
 
 /// Delete an identity (TLS cert + pchat seed) by label.

--- a/crates/mumble-tauri/ui/src/App.tsx
+++ b/crates/mumble-tauri/ui/src/App.tsx
@@ -33,6 +33,7 @@ const ChatPage = lazy(() => import("./pages/ChatPage"));
 const SettingsPage = lazy(() => import("./pages/settings"));
 const AdminPanel = lazy(() => import("./pages/admin"));
 const RoleEditorPage = lazy(() => import("./pages/admin/RoleEditorPage"));
+const NewRolePage = lazy(() => import("./pages/admin/NewRolePage"));
 const WelcomePage = lazy(() => import("./pages/WelcomePage"));
 const FriendsPage = lazy(() => import("./pages/FriendsPage"));
 const MarketplacePluginPage = lazy(() => import("./pages/marketplace/PluginPage"));
@@ -370,6 +371,7 @@ function MainApp() {
               <Route path="/friends" element={<FriendsPage />} />
               <Route path="/settings" element={<SettingsPage />} />
               <Route path="/admin" element={<AdminPanel />} />
+              <Route path="/admin/roles/new" element={<NewRolePage />} />
               <Route path="/admin/role/:groupName" element={<RoleEditorPage />} />
               <Route path="/marketplace/plugin/:id" element={<MarketplacePluginPage />} />
             </>

--- a/crates/mumble-tauri/ui/src/components/elements/TabbedPage.module.css
+++ b/crates/mumble-tauri/ui/src/components/elements/TabbedPage.module.css
@@ -104,7 +104,97 @@
 .mainArea {
   flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.mainScroll {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
+}
+
+/* Pinned footer (e.g. wizard step nav, a persistent save bar): a real flex
+   row below the scrollable area, not `position: sticky` - sticky only
+   engages once the content scrolls past it, so short content (e.g. the
+   first wizard step) would leave it stranded right under the content
+   instead of at the bottom of the panel. */
+.mainFooter {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 40px;
+  border-top: 1px solid var(--color-glass-border);
+  background: var(--color-surface-action-bar);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+@media (max-width: 768px) {
+  .mainFooter {
+    padding: 12px 16px;
+  }
+}
+
+/* --- Action-bar buttons ------------------------------------------
+   Shared by every `footer` consumer (wizard step nav, a persistent save
+   bar) so they read as one system instead of each page picking its own
+   button size/color. Deliberately larger than the toolbar's `.addBtn` /
+   `.saveBtn` (AdminPanel.module.css) - these are the primary action for
+   the page, not a secondary toolbar control. */
+
+.actionBtnGroup {
+  display: flex;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.actionBtn {
+  padding: 10px 20px;
+  font-size: 14px;
+  font-family: inherit;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.15s;
+  border: 1px solid var(--color-glass-border);
+  background: var(--color-glass);
+  color: var(--color-text-secondary);
+}
+
+.actionBtn:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  background: var(--color-glass-hover);
+  border-color: var(--color-glass-border-hover);
+}
+
+.actionBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.actionBtnPrimary {
+  color: var(--color-accent);
+  border-color: var(--color-accent-glow);
+  background: var(--color-accent-subtle);
+}
+
+.actionBtnPrimary:hover:not(:disabled) {
+  background: var(--color-accent-medium);
+  border-color: rgba(42, 171, 238, 0.4);
+}
+
+.actionBtnDanger {
+  color: var(--color-danger);
+  border-color: var(--color-danger-border);
+  background: transparent;
+}
+
+.actionBtnDanger:hover:not(:disabled) {
+  background: var(--color-danger-bg);
+  border-color: var(--color-danger-border-strong);
 }
 
 /* --- Responsive (mobile) ---------------------------------------- */

--- a/crates/mumble-tauri/ui/src/components/elements/TabbedPage.tsx
+++ b/crates/mumble-tauri/ui/src/components/elements/TabbedPage.tsx
@@ -15,11 +15,20 @@ interface TabbedPageProps<T extends string> {
   activeTab: T;
   onTabChange: (tab: T) => void;
   onBack: () => void;
-  /** Extra CSS class applied to `.mainArea` (e.g. grid layout for preview pane). */
+  /** Extra CSS class applied to the scrollable content area (e.g. grid
+   *  layout for a preview pane). */
   mainAreaClassName?: string;
   /** Optional content rendered in the sidebar between the heading and the tab
    *  list (e.g. a settings search box). */
   sidebarExtra?: ReactNode;
+  /**
+   * Optional non-scrolling bar pinned to the bottom of the main area (e.g.
+   * wizard step navigation, a persistent save bar). Unlike `position:
+   * sticky`, this stays at the bottom of the panel even when `children`
+   * don't fill the viewport - it's a fixed flex row below the scrollable
+   * content, not a scroll-dependent offset.
+   */
+  footer?: ReactNode;
   children: ReactNode;
 }
 
@@ -33,12 +42,13 @@ export function TabbedPage<T extends string>({
   onBack,
   mainAreaClassName,
   sidebarExtra,
+  footer,
   children,
 }: Readonly<TabbedPageProps<T>>) {
   const { t } = useTranslation("common");
-  const mainCls = mainAreaClassName
-    ? `${styles.mainArea} ${mainAreaClassName}`
-    : styles.mainArea;
+  const scrollCls = mainAreaClassName
+    ? `${styles.mainScroll} ${mainAreaClassName}`
+    : styles.mainScroll;
 
   return (
     <div className={styles.page}>
@@ -71,8 +81,11 @@ export function TabbedPage<T extends string>({
         </ul>
       </nav>
 
-      <div className={mainCls}>
-        {children}
+      <div className={styles.mainArea}>
+        <div className={scrollCls}>
+          {children}
+        </div>
+        {footer && <div className={styles.mainFooter}>{footer}</div>}
       </div>
     </div>
   );

--- a/crates/mumble-tauri/ui/src/components/onboarding/OnboardingAdminPanel.module.css
+++ b/crates/mumble-tauri/ui/src/components/onboarding/OnboardingAdminPanel.module.css
@@ -311,39 +311,6 @@
   align-self: flex-start;
 }
 
-.actions {
-  display: flex;
-  justify-content: flex-end;
-  padding-top: 4px;
-}
-
-.saveBtn {
-  padding: 11px 22px;
-  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-hover));
-  border: none;
-  border-radius: var(--radius-md);
-  color: #fff;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: opacity 0.2s, box-shadow 0.2s, transform 0.1s;
-  box-shadow: 0 4px 16px var(--color-accent-glow);
-}
-
-.saveBtn:hover:not(:disabled) {
-  opacity: 0.92;
-  box-shadow: 0 6px 24px var(--color-accent-glow);
-}
-
-.saveBtn:active:not(:disabled) {
-  transform: scale(0.98);
-}
-
-.saveBtn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .error {
   padding: 10px 12px;
   background: var(--color-danger-soft, rgba(239, 68, 68, 0.12));

--- a/crates/mumble-tauri/ui/src/components/onboarding/OnboardingAdminPanel.tsx
+++ b/crates/mumble-tauri/ui/src/components/onboarding/OnboardingAdminPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useAppStore } from "../../store";
@@ -11,6 +11,12 @@ import { Autocomplete, type AutocompleteOption } from "../elements/Autocomplete"
 import { PlusIcon, TrashIcon, HashIcon, SparklesIcon } from "../../icons";
 import { isOnboardingSupported, useOnboardingStore } from "./onboardingStore";
 import styles from "./OnboardingAdminPanel.module.css";
+import tabStyles from "../elements/TabbedPage.module.css";
+
+export interface OnboardingAdminPanelProps {
+  /** Hands the panel's Save bar up to `AdminPanel`'s shared pinned footer. */
+  readonly setFooter?: (footer: ReactNode) => void;
+}
 
 const MAX_QUESTIONS = 5;
 
@@ -70,7 +76,7 @@ function Toggle({
  * Admin editor for the server onboarding workflow.  Pre-populates from the
  * server-broadcast config and persists changes via `save_onboarding_config`.
  */
-export default function OnboardingAdminPanel() {
+export default function OnboardingAdminPanel({ setFooter }: Readonly<OnboardingAdminPanelProps>) {
   const remote = useOnboardingStore((s) => s.config);
   const busy = useOnboardingStore((s) => s.busy);
   const error = useOnboardingStore((s) => s.error);
@@ -145,6 +151,33 @@ export default function OnboardingAdminPanel() {
     };
     saveConfig(sanitized).catch(() => {});
   };
+
+  const footerNode = useMemo(() => {
+    if (!supported) return null;
+    return (
+      <>
+        {error ? <span className={styles.error}>{error}</span> : null}
+        <div className={tabStyles.actionBtnGroup}>
+          <button
+            type="button"
+            className={`${tabStyles.actionBtn} ${tabStyles.actionBtnPrimary}`}
+            onClick={handleSave}
+            disabled={busy}
+          >
+            {busy ? t("onboarding.admin.savingBtn") : t("onboarding.admin.saveBroadcastBtn")}
+          </button>
+        </div>
+      </>
+    );
+    // `handleSave` closes over `draft`, so depending on `draft` here (rather
+    // than on `handleSave` itself, which is a new closure every render) is
+    // what keeps this memoized button from firing a stale save.
+  }, [supported, draft, error, busy, t]);
+
+  useEffect(() => {
+    setFooter?.(footerNode);
+    return () => setFooter?.(null);
+  }, [footerNode, setFooter]);
 
   if (!supported) {
     return (
@@ -319,13 +352,6 @@ export default function OnboardingAdminPanel() {
         </button>
       ) : null}
 
-      {error ? <div className={styles.error}>{error}</div> : null}
-
-      <div className={styles.actions}>
-        <button className={styles.saveBtn} onClick={handleSave} disabled={busy}>
-          {busy ? t("onboarding.admin.savingBtn") : t("onboarding.admin.saveBroadcastBtn")}
-        </button>
-      </div>
     </div>
   );
 }

--- a/crates/mumble-tauri/ui/src/locales/de/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/de/settings.json
@@ -604,7 +604,12 @@
     "notFound": "Rolle {{name}} nicht gefunden.",
     "saving": "Speichern...",
     "saveChanges": "Änderungen speichern",
-    "deleteRole": "Rolle löschen"
+    "deleteRole": "Rolle löschen",
+    "newHeadingPrefix": "Neue Rolle: {{name}}",
+    "previous": "Zurück",
+    "next": "Weiter",
+    "createRole": "Rolle erstellen",
+    "cancel": "Abbrechen"
   },
   "roleDisplay": {
     "fieldName": "Rollenname",

--- a/crates/mumble-tauri/ui/src/locales/de/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/de/settings.json
@@ -576,6 +576,13 @@
   "channelAcl": {
     "title": "Kanäle / ACL",
     "searchChannels": "Kanäle suchen...",
+    "hideDmChannels": "DM-Kanäle ausblenden",
+    "filtersTitle": "Filter",
+    "hideEmptyChannels": "Leere Kanäle ausblenden",
+    "privateOnly": "Nur private Kanäle",
+    "topLevelOnly": "Nur oberste Ebene",
+    "customAclOnly": "Nur mit eigener ACL",
+    "customAclLoading": "Kanäle werden geprüft…",
     "selectChannel": "Kanal auswählen, um dessen ACL zu bearbeiten",
     "loadingAcl": "ACL wird geladen...",
     "saveChanges": "Änderungen speichern",

--- a/crates/mumble-tauri/ui/src/locales/de/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/de/settings.json
@@ -813,6 +813,14 @@
     "MANAGE_EMOTES": {
       "title": "Emotes verwalten",
       "description": "Benutzerdefinierte Server-Emotes verwalten."
+    },
+    "READ_REGISTER": {
+      "title": "Registrierte Benutzer auflisten",
+      "description": "Die Liste der registrierten Benutzer des Servers einsehen."
+    },
+    "SEE_CHANNEL": {
+      "title": "Versteckten Kanal sehen",
+      "description": "Diesen Kanal auch dann sehen, wenn er für Benutzer ohne Zugriff verborgen ist."
     }
   },
   "onboarding": {

--- a/crates/mumble-tauri/ui/src/locales/en/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/en/settings.json
@@ -614,7 +614,12 @@
     "notFound": "Role {{name}} not found.",
     "saving": "Saving...",
     "saveChanges": "Save changes",
-    "deleteRole": "Delete role"
+    "deleteRole": "Delete role",
+    "newHeadingPrefix": "New role: {{name}}",
+    "previous": "Previous",
+    "next": "Next",
+    "createRole": "Create role",
+    "cancel": "Cancel"
   },
   "roleDisplay": {
     "fieldName": "Role name",

--- a/crates/mumble-tauri/ui/src/locales/en/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/en/settings.json
@@ -576,6 +576,13 @@
   "channelAcl": {
     "title": "Channels / ACL",
     "searchChannels": "Search channels...",
+    "hideDmChannels": "Hide DM channels",
+    "filtersTitle": "Filters",
+    "hideEmptyChannels": "Hide empty channels",
+    "privateOnly": "Private channels only",
+    "topLevelOnly": "Top-level channels only",
+    "customAclOnly": "Custom ACL only",
+    "customAclLoading": "checking channels…",
     "selectChannel": "Select a channel to edit its ACL",
     "loadingAcl": "Loading ACL...",
     "saveChanges": "Save Changes",

--- a/crates/mumble-tauri/ui/src/locales/en/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/en/settings.json
@@ -823,6 +823,14 @@
     "MANAGE_EMOTES": {
       "title": "Manage emotes",
       "description": "Manage custom server emotes."
+    },
+    "READ_REGISTER": {
+      "title": "List registered users",
+      "description": "View the server's list of registered users."
+    },
+    "SEE_CHANNEL": {
+      "title": "See hidden channel",
+      "description": "See this channel even when it's hidden from users without access."
     }
   },
   "onboarding": {

--- a/crates/mumble-tauri/ui/src/locales/fr/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/fr/settings.json
@@ -813,6 +813,14 @@
     "MANAGE_EMOTES": {
       "title": "Gérer les émotes",
       "description": "Gérer les émotes personnalisées du serveur."
+    },
+    "READ_REGISTER": {
+      "title": "Lister les utilisateurs enregistrés",
+      "description": "Consulter la liste des utilisateurs enregistrés du serveur."
+    },
+    "SEE_CHANNEL": {
+      "title": "Voir le salon caché",
+      "description": "Voir ce salon même lorsqu'il est masqué aux utilisateurs sans accès."
     }
   },
   "onboarding": {

--- a/crates/mumble-tauri/ui/src/locales/fr/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/fr/settings.json
@@ -576,6 +576,13 @@
   "channelAcl": {
     "title": "Canaux / ACL",
     "searchChannels": "Rechercher des canaux...",
+    "hideDmChannels": "Masquer les canaux MP",
+    "filtersTitle": "Filtres",
+    "hideEmptyChannels": "Masquer les canaux vides",
+    "privateOnly": "Canaux privés uniquement",
+    "topLevelOnly": "Premier niveau uniquement",
+    "customAclOnly": "ACL personnalisée uniquement",
+    "customAclLoading": "Vérification des canaux…",
     "selectChannel": "Sélectionner un canal pour modifier ses ACL",
     "loadingAcl": "Chargement des ACL...",
     "saveChanges": "Enregistrer les modifications",

--- a/crates/mumble-tauri/ui/src/locales/fr/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/fr/settings.json
@@ -604,7 +604,12 @@
     "notFound": "Rôle {{name}} introuvable.",
     "saving": "Enregistrement...",
     "saveChanges": "Enregistrer les modifications",
-    "deleteRole": "Supprimer le rôle"
+    "deleteRole": "Supprimer le rôle",
+    "newHeadingPrefix": "Nouveau rôle : {{name}}",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "createRole": "Créer le rôle",
+    "cancel": "Annuler"
   },
   "roleDisplay": {
     "fieldName": "Nom du rôle",

--- a/crates/mumble-tauri/ui/src/locales/zh/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/zh/settings.json
@@ -738,7 +738,12 @@
     "notFound": "未找到身份组 {{name}}。",
     "saving": "保存中…",
     "saveChanges": "保存修改",
-    "deleteRole": "删除身份组"
+    "deleteRole": "删除身份组",
+    "newHeadingPrefix": "新建身份组：{{name}}",
+    "previous": "上一步",
+    "next": "下一步",
+    "createRole": "创建身份组",
+    "cancel": "取消"
   },
   "roleDisplay": {
     "fieldName": "身份组名称",

--- a/crates/mumble-tauri/ui/src/locales/zh/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/zh/settings.json
@@ -710,6 +710,13 @@
   "channelAcl": {
     "title": "频道 / ACL",
     "searchChannels": "搜索频道…",
+    "hideDmChannels": "隐藏私信频道",
+    "filtersTitle": "筛选",
+    "hideEmptyChannels": "隐藏空频道",
+    "privateOnly": "仅私密频道",
+    "topLevelOnly": "仅顶级频道",
+    "customAclOnly": "仅自定义 ACL",
+    "customAclLoading": "正在检查频道…",
     "selectChannel": "选择一个频道以编辑其 ACL",
     "loadingAcl": "正在加载 ACL…",
     "saveChanges": "保存修改",

--- a/crates/mumble-tauri/ui/src/locales/zh/settings.json
+++ b/crates/mumble-tauri/ui/src/locales/zh/settings.json
@@ -923,6 +923,14 @@
     "MANAGE_EMOTES": {
       "title": "管理表情",
       "description": "管理服务器自定义表情。"
+    },
+    "READ_REGISTER": {
+      "title": "查看注册用户列表",
+      "description": "查看服务器的注册用户列表。"
+    },
+    "SEE_CHANNEL": {
+      "title": "查看隐藏频道",
+      "description": "即使该频道对无权限用户隐藏，仍可查看该频道。"
     }
   },
   "onboarding": {

--- a/crates/mumble-tauri/ui/src/pages/admin/AdminPanel.module.css
+++ b/crates/mumble-tauri/ui/src/pages/admin/AdminPanel.module.css
@@ -829,7 +829,7 @@ button.aclCardHeader:hover {
   border-radius: 0.5rem;
   padding: 0.65rem 0.85rem;
   cursor: pointer;
-  color: var(--text-primary, #e7e9ec);
+  color: var(--color-text-primary, #e7e9ec);
   transition: background 120ms ease;
 }
 
@@ -839,7 +839,7 @@ button.aclCardHeader:hover {
 
 .roleMeta {
   font-size: 0.78rem;
-  color: var(--text-tertiary, #7a7d83);
+  color: var(--color-text-muted, #7a7d83);
   margin-left: auto;
 }
 
@@ -847,7 +847,7 @@ button.aclCardHeader:hover {
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--text-tertiary, #7a7d83);
+  color: var(--color-text-muted, #7a7d83);
 }
 
 /* --- Role editor ----------------------------------------------- */
@@ -877,12 +877,6 @@ button.aclCardHeader:hover {
   align-self: flex-start;
 }
 
-.editorActions {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
-}
-
 .fieldset {
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.45rem;
@@ -898,7 +892,7 @@ button.aclCardHeader:hover {
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--text-tertiary, #7a7d83);
+  color: var(--color-text-muted, #7a7d83);
 }
 
 .input {
@@ -906,7 +900,7 @@ button.aclCardHeader:hover {
   border-radius: 0.35rem;
   border: 1px solid rgba(255, 255, 255, 0.16);
   background: rgba(0, 0, 0, 0.25);
-  color: var(--text-primary, #e7e9ec);
+  color: var(--color-text-primary, #e7e9ec);
   font-size: 0.85rem;
   width: 100%;
   box-sizing: border-box;
@@ -931,7 +925,7 @@ button.aclCardHeader:hover {
 .metadataKey {
   font-family: monospace;
   font-size: 0.85rem;
-  color: var(--text-secondary, #b6b9bf);
+  color: var(--color-text-secondary, #b6b9bf);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -962,20 +956,6 @@ button.aclCardHeader:hover {
   font-size: 0.78rem;
 }
 
-.dangerBtn {
-  background: rgba(255, 80, 80, 0.12);
-  border: 1px solid rgba(255, 80, 80, 0.4);
-  color: #ff7e7e;
-  border-radius: 0.4rem;
-  padding: 0.4rem 0.75rem;
-  cursor: pointer;
-  font-size: 0.85rem;
-}
-
-.dangerBtn:hover {
-  background: rgba(255, 80, 80, 0.2);
-}
-
 .userRoleChips {
   display: inline-flex;
   flex-wrap: wrap;
@@ -993,7 +973,7 @@ button.aclCardHeader:hover {
   border-radius: 0.35rem;
   border: 1px solid rgba(255, 255, 255, 0.16);
   background-color: rgba(0, 0, 0, 0.25);
-  color: var(--text-primary, #e7e9ec);
+  color: var(--color-text-primary, #e7e9ec);
   font-size: 0.85rem;
   width: 100%;
   box-sizing: border-box;
@@ -1005,19 +985,6 @@ button.aclCardHeader:hover {
 
 .select::-ms-expand {
   display: none;
-}
-
-.editorDangerZone {
-  margin-top: 1.5rem;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(255, 80, 80, 0.18);
-}
-
-.dangerBtnFull {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  font-size: 0.9rem;
-  font-weight: 600;
 }
 
 /* --- Permissions list (single toggle per permission) ---------- */
@@ -1059,14 +1026,14 @@ button.aclCardHeader:hover {
   display: block;
   font-size: 0.88rem;
   font-weight: 500;
-  color: var(--text-primary, #e7e9ec);
+  color: var(--color-text-primary, #e7e9ec);
   cursor: pointer;
 }
 
 .permDesc {
   margin: 0.15rem 0 0;
   font-size: 0.75rem;
-  color: var(--text-tertiary, #7a7d83);
+  color: var(--color-text-muted, #7a7d83);
   line-height: 1.35;
 }
 

--- a/crates/mumble-tauri/ui/src/pages/admin/AdminPanel.module.css
+++ b/crates/mumble-tauri/ui/src/pages/admin/AdminPanel.module.css
@@ -501,11 +501,35 @@
 
 .aclSplitView {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 260px 1fr 240px;
   gap: 16px;
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+
+.aclFiltersPane {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border-left: 1px solid var(--color-border);
+  padding-left: 16px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.aclFiltersTitle {
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+}
+
+.aclFiltersHint {
+  color: var(--color-text-muted);
+  font-style: italic;
 }
 
 .aclTreePane {
@@ -531,6 +555,20 @@
   right: 12px;
   top: 50%;
   transform: translateY(-50%);
+}
+
+.aclTreeFilterRow {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 0 8px 10px;
+  flex-shrink: 0;
+}
+
+.aclTreeFilterLabel {
+  font-size: 13px;
+  color: var(--color-text-secondary);
 }
 
 .aclTreeList {
@@ -781,6 +819,13 @@ button.aclCardHeader:hover {
     border-right: none;
     border-bottom: 1px solid var(--color-border);
     max-height: 200px;
+  }
+
+  .aclFiltersPane {
+    border-left: none;
+    border-top: 1px solid var(--color-border);
+    padding-left: 0;
+    padding-top: 12px;
   }
 }
 
@@ -1421,3 +1466,4 @@ button.aclCardHeader:hover {
   flex-direction: column;
   gap: 4px;
 }
+

--- a/crates/mumble-tauri/ui/src/pages/admin/ChannelAclTab.tsx
+++ b/crates/mumble-tauri/ui/src/pages/admin/ChannelAclTab.tsx
@@ -8,12 +8,16 @@ import { useSearchParams } from "react-router-dom";
 import { useAppStore } from "../../store";
 import { TID } from "../../testids";
 import { PERM_ENTER } from "../../utils/permissions";
+import { filterVisibleChannels, isDmChannel } from "../../utils/channelVisibility";
 import type { AclData, AclEntry, AclGroup, ChannelEntry, RegisteredUser } from "../../types";
 import { AclRulesPanel } from "./AclRulesPanel";
 import { GroupsPanel } from "./GroupsPanel";
 import { AccessUsersPanel } from "./AccessUsersPanel";
-import { buildChannelTree, type TreeNode } from "./channelAclModel";
+import { ChannelFiltersPanel } from "./ChannelFiltersPanel";
+import { buildChannelTree, hasCustomAcl, limitTreeDepth, type TreeNode } from "./channelAclModel";
 import styles from "./AdminPanel.module.css";
+
+const NO_LISTENED_CHANNELS: ReadonlySet<number> = new Set();
 
 type AclTab = "groups" | "rules" | "users";
 
@@ -52,6 +56,14 @@ export function ChannelAclTab() {
   const [loading, setLoading] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [search, setSearch] = useState("");
+  const [hideDmChannels, setHideDmChannels] = useState(false);
+  const [hideEmptyChannels, setHideEmptyChannels] = useState(false);
+  const [privateOnly, setPrivateOnly] = useState(false);
+  const [topLevelOnly, setTopLevelOnly] = useState(false);
+  const [customAclOnly, setCustomAclOnly] = useState(false);
+  // Populated by a bulk `request_acl` sweep the first time `customAclOnly`
+  // is turned on (there's no batch ACL endpoint - see the effect below).
+  const [customAclCache, setCustomAclCache] = useState<Map<number, boolean>>(new Map());
   const [activeTab, setActiveTab] = useState<AclTab>("rules");
   const [expanded, setExpanded] = useState<Set<number>>(() => new Set());
   const [registeredNames, setRegisteredNames] = useState<Map<number, string>>(new Map());
@@ -60,11 +72,47 @@ export function ChannelAclTab() {
     { x: number; y: number; channel: ChannelEntry; confirming?: boolean } | null
   >(null);
 
-  const tree = useMemo(() => buildChannelTree(channels), [channels]);
+  const visibleChannels = useMemo(() => {
+    let base = channels;
+    if (hideDmChannels) base = base.filter((c) => !isDmChannel(c));
+    if (privateOnly) base = base.filter((c) => c.detached);
+    if (customAclOnly) base = base.filter((c) => customAclCache.get(c.id) === true);
+    if (hideEmptyChannels) {
+      base = filterVisibleChannels(base, users, {
+        currentChannel: null,
+        selectedChannel,
+        listenedChannels: NO_LISTENED_CHANNELS,
+      });
+    }
+    return base;
+  }, [channels, users, hideDmChannels, privateOnly, customAclOnly, customAclCache, hideEmptyChannels, selectedChannel]);
+  const tree = useMemo(() => {
+    const built = buildChannelTree(visibleChannels);
+    return topLevelOnly ? limitTreeDepth(built, 1) : built;
+  }, [visibleChannels, topLevelOnly]);
   const matchedIds = useMemo(
     () => (search ? filterTree(tree, search) : null),
     [tree, search],
   );
+
+  // "Custom ACL only": no batch endpoint exists, so sweep `request_acl` for
+  // every channel not yet requested once the filter is turned on. The
+  // shared "acl" listener below feeds results back into `customAclCache` as
+  // they arrive. Tracked in a ref (not state) so a response arriving mid-sweep
+  // doesn't re-run this effect and re-request every other still-pending
+  // channel - each channel is asked for exactly once per session.
+  const requestedCustomAclRef = useRef<Set<number>>(new Set());
+  useEffect(() => {
+    if (!customAclOnly) return;
+    for (const c of channels) {
+      if (!requestedCustomAclRef.current.has(c.id)) {
+        requestedCustomAclRef.current.add(c.id);
+        invoke("request_acl", { channelId: c.id }).catch(() => {});
+      }
+    }
+  }, [customAclOnly, channels]);
+  const customAclLoading =
+    customAclOnly && channels.some((c) => !customAclCache.has(c.id));
 
   // Auto-expand root on first render.
   useEffect(() => {
@@ -90,10 +138,30 @@ export function ChannelAclTab() {
     };
   }, []);
 
-  // Listen for ACL events from the backend.
+  // Listen for ACL events from the backend. Subscribed once for the whole
+  // component lifetime, and the "is this for the selected channel?" check
+  // reads a ref, not state. Both halves matter: re-subscribing per selection
+  // (`[selectedChannel]` deps) loses responses on a fast server two ways -
+  // the response can arrive before the effect re-runs, so the live listener
+  // still compares against the *previous* selection and drops it; and
+  // `listen`/`unlisten` are async IPC round-trips, so re-registration has a
+  // window with no listener at all. Either way the pane sticks on "Loading
+  // ACL...". The ref is written synchronously in `handleChannelSelect`
+  // BEFORE `request_acl` is sent, so it can never lag the response.
+  const selectedChannelRef = useRef<number | null>(null);
+
   useEffect(() => {
     const unlisten = listen<AclData>("acl", (event) => {
-      setAclData(event.payload);
+      const data = event.payload;
+      // Feeds the "custom ACL" filter's cache regardless of selection;
+      // harmless when no bulk sweep is running (see the effect above it).
+      setCustomAclCache((prev) => {
+        const next = new Map(prev);
+        next.set(data.channel_id, hasCustomAcl(data));
+        return next;
+      });
+      if (data.channel_id !== selectedChannelRef.current) return;
+      setAclData(data);
       setLoading(false);
       setDirty(false);
     });
@@ -101,6 +169,7 @@ export function ChannelAclTab() {
   }, []);
 
   const handleChannelSelect = useCallback((channelId: number) => {
+    selectedChannelRef.current = channelId;
     setSelectedChannel(channelId);
     setLoading(true);
     setAclData(null);
@@ -177,6 +246,7 @@ export function ChannelAclTab() {
       try {
         await deleteChannel(channel.id);
         if (selectedChannel === channel.id) {
+          selectedChannelRef.current = null;
           setSelectedChannel(null);
           setAclData(null);
         }
@@ -424,6 +494,21 @@ export function ChannelAclTab() {
             </>
           )}
         </div>
+
+        {/* Right: Filters */}
+        <ChannelFiltersPanel
+          hideDmChannels={hideDmChannels}
+          onHideDmChannelsChange={setHideDmChannels}
+          hideEmptyChannels={hideEmptyChannels}
+          onHideEmptyChannelsChange={setHideEmptyChannels}
+          privateOnly={privateOnly}
+          onPrivateOnlyChange={setPrivateOnly}
+          topLevelOnly={topLevelOnly}
+          onTopLevelOnlyChange={setTopLevelOnly}
+          customAclOnly={customAclOnly}
+          onCustomAclOnlyChange={setCustomAclOnly}
+          customAclLoading={customAclLoading}
+        />
       </div>
 
       {/* Channel context menu (right-click in the tree) */}

--- a/crates/mumble-tauri/ui/src/pages/admin/ChannelFiltersPanel.tsx
+++ b/crates/mumble-tauri/ui/src/pages/admin/ChannelFiltersPanel.tsx
@@ -1,0 +1,98 @@
+import { useTranslation } from "react-i18next";
+import { TID } from "../../testids";
+import styles from "./AdminPanel.module.css";
+
+interface FilterToggleRowProps {
+  readonly label: string;
+  readonly checked: boolean;
+  readonly onChange: (v: boolean) => void;
+  readonly testId: string;
+  readonly hint?: string;
+}
+
+function FilterToggleRow({ label, checked, onChange, testId, hint }: Readonly<FilterToggleRowProps>) {
+  return (
+    <div className={styles.aclTreeFilterRow}>
+      <span className={styles.aclTreeFilterLabel}>
+        {label}
+        {hint && <span className={styles.aclFiltersHint}> - {hint}</span>}
+      </span>
+      <label className={styles.toggleSwitch}>
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          data-testid={testId}
+        />
+        <span className={styles.toggleSlider} aria-hidden="true" />
+      </label>
+    </div>
+  );
+}
+
+export interface ChannelFiltersPanelProps {
+  readonly hideDmChannels: boolean;
+  readonly onHideDmChannelsChange: (v: boolean) => void;
+  readonly hideEmptyChannels: boolean;
+  readonly onHideEmptyChannelsChange: (v: boolean) => void;
+  readonly privateOnly: boolean;
+  readonly onPrivateOnlyChange: (v: boolean) => void;
+  readonly topLevelOnly: boolean;
+  readonly onTopLevelOnlyChange: (v: boolean) => void;
+  readonly customAclOnly: boolean;
+  readonly onCustomAclOnlyChange: (v: boolean) => void;
+  readonly customAclLoading: boolean;
+}
+
+/**
+ * Third column of the "Channels / ACL" admin tab: every tree filter in one
+ * place, always reachable regardless of whether a channel is selected (the
+ * middle detail pane swaps between "select a channel" and the ACL editor).
+ */
+export function ChannelFiltersPanel({
+  hideDmChannels, onHideDmChannelsChange,
+  hideEmptyChannels, onHideEmptyChannelsChange,
+  privateOnly, onPrivateOnlyChange,
+  topLevelOnly, onTopLevelOnlyChange,
+  customAclOnly, onCustomAclOnlyChange,
+  customAclLoading,
+}: Readonly<ChannelFiltersPanelProps>) {
+  const { t } = useTranslation("settings");
+
+  return (
+    <div className={styles.aclFiltersPane}>
+      <h3 className={styles.aclFiltersTitle}>{t("channelAcl.filtersTitle")}</h3>
+      <FilterToggleRow
+        label={t("channelAcl.hideDmChannels")}
+        checked={hideDmChannels}
+        onChange={onHideDmChannelsChange}
+        testId={TID.aclHideDmChannels}
+      />
+      <FilterToggleRow
+        label={t("channelAcl.hideEmptyChannels")}
+        checked={hideEmptyChannels}
+        onChange={onHideEmptyChannelsChange}
+        testId={TID.aclHideEmptyChannels}
+      />
+      <FilterToggleRow
+        label={t("channelAcl.privateOnly")}
+        checked={privateOnly}
+        onChange={onPrivateOnlyChange}
+        testId={TID.aclPrivateOnly}
+      />
+      <FilterToggleRow
+        label={t("channelAcl.topLevelOnly")}
+        checked={topLevelOnly}
+        onChange={onTopLevelOnlyChange}
+        testId={TID.aclTopLevelOnly}
+      />
+      <FilterToggleRow
+        label={t("channelAcl.customAclOnly")}
+        checked={customAclOnly}
+        onChange={onCustomAclOnlyChange}
+        testId={TID.aclCustomAclOnly}
+        hint={customAclLoading ? t("channelAcl.customAclLoading") : undefined}
+      />
+    </div>
+  );
+}

--- a/crates/mumble-tauri/ui/src/pages/admin/NewRolePage.tsx
+++ b/crates/mumble-tauri/ui/src/pages/admin/NewRolePage.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { invoke } from "@tauri-apps/api/core";
+import { acquireRegisteredTextures, releaseRegisteredTextures } from "../../registeredTextureLease";
+import { listen } from "@tauri-apps/api/event";
+import { useNavigate } from "react-router-dom";
+import { useAppStore } from "../../store";
+import { TabbedPage, type TabDef } from "../../components/elements/TabbedPage";
+import { PaletteIcon, LockIcon, UsersGroupIcon } from "../../icons";
+import type { AclData, AclEntry, AclGroup, RegisteredUser } from "../../types";
+import { TID } from "../../testids";
+import { useChannelAcl } from "./useChannelAcl";
+import { rootChannelId } from "./rootChannel";
+import { RoleDisplayPanel } from "./RoleDisplayPanel";
+import { RolePermissionsPanel } from "./RolePermissionsPanel";
+import { RoleMembersPanel } from "./RoleMembersPanel";
+import styles from "./AdminPanel.module.css";
+import tabStyles from "../../components/elements/TabbedPage.module.css";
+
+type Step = "display" | "permissions" | "members";
+const STEPS: readonly Step[] = ["display", "permissions", "members"];
+
+/** Picks `new_role`, or `new_role_2`/`_3`/... if that's already taken. */
+function draftName(existing: ReadonlySet<string>): string {
+  const baseName = "new_role";
+  let name = baseName;
+  let suffix = 1;
+  while (existing.has(name)) {
+    suffix += 1;
+    name = `${baseName}_${suffix}`;
+  }
+  return name;
+}
+
+function makeDraftGroup(existing: ReadonlySet<string>): AclGroup {
+  return {
+    name: draftName(existing),
+    inherited: false,
+    inherit: true,
+    inheritable: true,
+    add: [],
+    remove: [],
+    inherited_members: [],
+    color: null,
+    icon: null,
+    style_preset: null,
+    metadata: {},
+  };
+}
+
+/**
+ * Wizard for creating a new server role (`/admin/roles/new`), distinct from
+ * {@link ../../pages/admin/RoleEditorPage} which edits an already-persisted
+ * one. The draft group (and any permission-entry edits) live only in local
+ * state - nothing is sent to the server until "Create role" on the final
+ * step, so navigating away (Back/Cancel) cleanly discards it.
+ */
+export default function NewRolePage() {
+  const navigate = useNavigate();
+  const { t } = useTranslation("settings");
+  const channels = useAppStore((s) => s.channels);
+  const rootId = useMemo(() => rootChannelId(channels), [channels]);
+  const { acl, loading, save } = useChannelAcl(rootId);
+
+  const [step, setStep] = useState<Step>("display");
+  const [draftGroup, setDraftGroup] = useState<AclGroup | null>(null);
+  const [draftAcls, setDraftAcls] = useState<AclEntry[] | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [registeredUsers, setRegisteredUsers] = useState<RegisteredUser[]>([]);
+
+  useEffect(() => {
+    const unlisten = listen<RegisteredUser[]>("user-list", (e) => setRegisteredUsers(e.payload));
+    acquireRegisteredTextures();
+    invoke("request_user_list").catch(() => {});
+    return () => {
+      unlisten.then((f) => f());
+      releaseRegisteredTextures();
+    };
+  }, []);
+
+  // Seed the draft once the ACL has loaded (need existing group names to
+  // pick a non-clashing default name, and the existing ACL entries as the
+  // base for the Permissions step).
+  useEffect(() => {
+    if (!acl || draftGroup) return;
+    setDraftGroup(makeDraftGroup(new Set(acl.groups.map((g) => g.name))));
+    setDraftAcls(acl.acls);
+  }, [acl, draftGroup]);
+
+  const patchDraft = (patch: Partial<AclGroup>) => {
+    setDraftGroup((g) => (g ? { ...g, ...patch } : g));
+  };
+
+  // What RolePermissionsPanel edits against: the real ACL's entries swapped
+  // for the draft's (possibly already-edited) copy, so toggling a permission
+  // for the not-yet-created role works the same way it does for a real one.
+  const previewAcl: AclData | null = useMemo(
+    () => (acl && draftAcls ? { ...acl, acls: draftAcls } : null),
+    [acl, draftAcls],
+  );
+
+  const stepIdx = STEPS.indexOf(step);
+  const isFirstStep = stepIdx === 0;
+  const isLastStep = stepIdx === STEPS.length - 1;
+
+  const goBack = () => navigate("/admin?tab=roles");
+
+  const handleCreate = async () => {
+    if (!acl || !draftGroup || !draftAcls) return;
+    setCreating(true);
+    try {
+      await save({ ...acl, groups: [...acl.groups, draftGroup], acls: draftAcls });
+      navigate(`/admin/role/${encodeURIComponent(draftGroup.name)}`);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const tabs: TabDef<Step>[] = [
+    { id: "display",     label: t("roleEditor.tabDisplay"),     icon: <PaletteIcon    width={16} height={16} /> },
+    { id: "permissions", label: t("roleEditor.tabPermissions"), icon: <LockIcon       width={16} height={16} /> },
+    { id: "members",     label: t("roleEditor.tabMembers"),     icon: <UsersGroupIcon width={16} height={16} /> },
+  ];
+
+  let body: React.ReactNode;
+  if ((loading && !acl) || !draftGroup || !previewAcl) {
+    body = <div className={styles.dimText}>{t("roleEditor.loadingRole")}</div>;
+  } else if (step === "display") {
+    body = <RoleDisplayPanel role={draftGroup} onPatch={patchDraft} disabled={creating} />;
+  } else if (step === "permissions") {
+    body = (
+      <RolePermissionsPanel
+        acl={previewAcl}
+        roleName={draftGroup.name}
+        onAclChange={(next) => setDraftAcls(next.acls)}
+        disabled={creating}
+      />
+    );
+  } else {
+    body = (
+      <RoleMembersPanel
+        role={draftGroup}
+        onPatch={patchDraft}
+        registeredUsers={registeredUsers}
+        disabled={creating}
+      />
+    );
+  }
+
+  const footer = (
+    <>
+      <button
+        type="button"
+        className={tabStyles.actionBtn}
+        onClick={goBack}
+        disabled={creating}
+        data-testid={TID.roleWizardCancel}
+      >
+        {t("roleEditor.cancel")}
+      </button>
+      <div className={tabStyles.actionBtnGroup}>
+        {!isFirstStep && (
+          <button
+            type="button"
+            className={tabStyles.actionBtn}
+            onClick={() => setStep(STEPS[stepIdx - 1])}
+            disabled={creating}
+            data-testid={TID.roleWizardPrev}
+          >
+            {t("roleEditor.previous")}
+          </button>
+        )}
+        {!isLastStep && (
+          <button
+            type="button"
+            className={`${tabStyles.actionBtn} ${tabStyles.actionBtnPrimary}`}
+            onClick={() => setStep(STEPS[stepIdx + 1])}
+            disabled={creating}
+            data-testid={TID.roleWizardNext}
+          >
+            {t("roleEditor.next")}
+          </button>
+        )}
+        {isLastStep && (
+          <button
+            type="button"
+            className={`${tabStyles.actionBtn} ${tabStyles.actionBtnPrimary}`}
+            onClick={handleCreate}
+            disabled={creating || !draftGroup}
+            data-testid={TID.roleWizardCreate}
+          >
+            {creating ? t("roleEditor.saving") : t("roleEditor.createRole")}
+          </button>
+        )}
+      </div>
+    </>
+  );
+
+  return (
+    <TabbedPage
+      heading={t("roleEditor.newHeadingPrefix", { name: draftGroup?.name ?? "" })}
+      tabs={tabs}
+      activeTab={step}
+      onTabChange={setStep}
+      onBack={goBack}
+      footer={footer}
+    >
+      <div className={styles.content}>
+        {body}
+      </div>
+    </TabbedPage>
+  );
+}

--- a/crates/mumble-tauri/ui/src/pages/admin/RoleDisplayPanel.tsx
+++ b/crates/mumble-tauri/ui/src/pages/admin/RoleDisplayPanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { AclGroup } from "../../types";
+import { TID } from "../../testids";
 import { RoleColorPicker } from "../../components/elements/role/RoleColorPicker";
 import { RoleIconPicker } from "../../components/elements/role/RoleIconPicker";
 import { RolePreviewCard } from "../../components/elements/role/RolePreviewCard";
@@ -49,6 +50,7 @@ export function RoleDisplayPanel({ role, onPatch, disabled }: RoleDisplayPanelPr
             value={role.name}
             onChange={(e) => onPatch({ name: e.target.value })}
             disabled={disabled || role.inherited}
+            data-testid={TID.roleNameInput}
           />
         </label>
 

--- a/crates/mumble-tauri/ui/src/pages/admin/RoleEditorPage.tsx
+++ b/crates/mumble-tauri/ui/src/pages/admin/RoleEditorPage.tsx
@@ -8,6 +8,7 @@ import { useAppStore } from "../../store";
 import { TabbedPage, type TabDef } from "../../components/elements/TabbedPage";
 import { PaletteIcon, LockIcon, UsersGroupIcon } from "../../icons";
 import type { AclGroup, RegisteredUser } from "../../types";
+import { TID } from "../../testids";
 import { useChannelAcl } from "./useChannelAcl";
 import { rootChannelId } from "./rootChannel";
 import { RoleDisplayPanel } from "./RoleDisplayPanel";
@@ -57,8 +58,8 @@ export default function RoleEditorPage() {
     if (!acl || roleIdx === -1) return;
     const next = { ...acl, groups: acl.groups.filter((_, i) => i !== roleIdx) };
     setAcl(next);
-    await save();
-    navigate("/admin");
+    await save(next);
+    navigate("/admin?tab=roles");
   };
 
   let body: React.ReactNode;
@@ -66,7 +67,7 @@ export default function RoleEditorPage() {
     body = <div className={styles.dimText}>{t("roleEditor.loadingRole")}</div>;
   } else if (!role) {
     body = (
-      <div className={styles.dimText}>
+      <div className={styles.dimText} data-testid={TID.roleEditorNotFound} data-role-name={roleName}>
         {t("roleEditor.notFound", { name: roleName })}
       </div>
     );
@@ -96,7 +97,7 @@ export default function RoleEditorPage() {
       tabs={subTabs}
       activeTab={tab}
       onTabChange={setTab}
-      onBack={() => navigate("/admin")}
+      onBack={() => navigate("/admin?tab=roles")}
     >
       <div className={styles.content}>
         <div className={styles.editorActions}>

--- a/crates/mumble-tauri/ui/src/pages/admin/RoleEditorPage.tsx
+++ b/crates/mumble-tauri/ui/src/pages/admin/RoleEditorPage.tsx
@@ -15,6 +15,7 @@ import { RoleDisplayPanel } from "./RoleDisplayPanel";
 import { RolePermissionsPanel } from "./RolePermissionsPanel";
 import { RoleMembersPanel } from "./RoleMembersPanel";
 import styles from "./AdminPanel.module.css";
+import tabStyles from "../../components/elements/TabbedPage.module.css";
 
 type SubTab = "display" | "permissions" | "members";
 
@@ -91,6 +92,34 @@ export default function RoleEditorPage() {
     );
   }
 
+  const canDelete = role != null && !role.inherited;
+  const footer = canDelete || dirty ? (
+    <>
+      {canDelete && (
+        <button
+          type="button"
+          className={`${tabStyles.actionBtn} ${tabStyles.actionBtnDanger}`}
+          onClick={handleDelete}
+          disabled={saving}
+        >
+          {t("roleEditor.deleteRole")}
+        </button>
+      )}
+      <div className={tabStyles.actionBtnGroup}>
+        {dirty && (
+          <button
+            type="button"
+            className={`${tabStyles.actionBtn} ${tabStyles.actionBtnPrimary}`}
+            onClick={() => save()}
+            disabled={saving}
+          >
+            {saving ? t("roleEditor.saving") : t("roleEditor.saveChanges")}
+          </button>
+        )}
+      </div>
+    </>
+  ) : undefined;
+
   return (
     <TabbedPage
       heading={t("roleEditor.headingPrefix", { name: roleName })}
@@ -98,33 +127,10 @@ export default function RoleEditorPage() {
       activeTab={tab}
       onTabChange={setTab}
       onBack={() => navigate("/admin?tab=roles")}
+      footer={footer}
     >
       <div className={styles.content}>
-        <div className={styles.editorActions}>
-          {dirty && (
-            <button
-              type="button"
-              className={styles.saveBtn}
-              onClick={() => save()}
-              disabled={saving}
-            >
-              {saving ? t("roleEditor.saving") : t("roleEditor.saveChanges")}
-            </button>
-          )}
-        </div>
         {body}
-        {role && !role.inherited && (
-          <div className={styles.editorDangerZone}>
-            <button
-              type="button"
-              className={`${styles.dangerBtn} ${styles.dangerBtnFull}`}
-              onClick={handleDelete}
-              disabled={saving}
-            >
-              {t("roleEditor.deleteRole")}
-            </button>
-          </div>
-        )}
       </div>
     </TabbedPage>
   );

--- a/crates/mumble-tauri/ui/src/pages/admin/RolesListPanel.tsx
+++ b/crates/mumble-tauri/ui/src/pages/admin/RolesListPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useAppStore } from "../../store";
 import type { AclGroup } from "../../types";
+import { TID } from "../../testids";
 import { RoleChip } from "../../components/elements/role/RoleChip";
 import { useChannelAcl } from "./useChannelAcl";
 import { rootChannelId } from "./rootChannel";
@@ -13,7 +14,7 @@ export function RolesListPanel() {
   const navigate = useNavigate();
   const { t } = useTranslation("settings");
   const rootId = useMemo(() => rootChannelId(channels), [channels]);
-  const { acl, loading, dirty, saving, setAcl, save } = useChannelAcl(rootId);
+  const { acl, loading } = useChannelAcl(rootId);
   const [search, setSearch] = useState("");
 
   const visibleRoles = useMemo(() => {
@@ -26,32 +27,10 @@ export function RolesListPanel() {
 
   const memberCount = (group: AclGroup): number => group.add.length + group.inherited_members.length;
 
-  const handleCreate = () => {
-    if (!acl) return;
-    const baseName = "new_role";
-    const existing = new Set(acl.groups.map((g) => g.name));
-    let name = baseName;
-    let suffix = 1;
-    while (existing.has(name)) {
-      suffix += 1;
-      name = `${baseName}_${suffix}`;
-    }
-    const newGroup: AclGroup = {
-      name,
-      inherited: false,
-      inherit: true,
-      inheritable: true,
-      add: [],
-      remove: [],
-      inherited_members: [],
-      color: null,
-      icon: null,
-      style_preset: null,
-      metadata: {},
-    };
-    setAcl({ ...acl, groups: [...acl.groups, newGroup] });
-    save().then(() => navigate(`/admin/role/${encodeURIComponent(name)}`));
-  };
+  // Nothing is created here: this only opens the new-role wizard
+  // (`/admin/roles/new`), which persists the draft itself once its final
+  // step's "Create role" button is clicked.
+  const handleCreate = () => navigate("/admin/roles/new");
 
   return (
     <div className={styles.rolesPanel}>
@@ -68,13 +47,18 @@ export function RolesListPanel() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
-        <button type="button" className={styles.addBtn} onClick={handleCreate} disabled={!acl || saving}>
+        <button
+          type="button"
+          className={styles.addBtn}
+          onClick={handleCreate}
+          disabled={!acl}
+          data-testid={TID.rolesCreateButton}
+        >
           {t("roles.createRole")}
         </button>
       </div>
 
       {loading && !acl && <div className={styles.dimText}>{t("roles.loadingRoles")}</div>}
-      {dirty && <div className={styles.dimText}>{t("roles.saving")}</div>}
 
       {acl && visibleRoles.length === 0 && (
         <div className={styles.dimText}>{t("roles.noMatch")}</div>
@@ -87,6 +71,8 @@ export function RolesListPanel() {
               type="button"
               className={styles.roleRow}
               onClick={() => navigate(`/admin/role/${encodeURIComponent(group.name)}`)}
+              data-testid={TID.roleListRow}
+              data-role-name={group.name}
             >
               <RoleChip
                 name={group.name}

--- a/crates/mumble-tauri/ui/src/pages/admin/ServerSettingsTab.module.css
+++ b/crates/mumble-tauri/ui/src/pages/admin/ServerSettingsTab.module.css
@@ -8,13 +8,13 @@
 
 .empty {
   padding: 32px 8px;
-  color: var(--text-secondary, #9aa6b8);
+  color: var(--color-text-secondary, #9aa6b8);
   font-size: 0.9rem;
 }
 
 .intro {
   font-size: 0.85rem;
-  color: var(--text-secondary, #9aa6b8);
+  color: var(--color-text-secondary, #9aa6b8);
   line-height: 1.4;
 }
 
@@ -28,8 +28,8 @@
   margin: 0;
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--text-primary, #fff);
-  border-bottom: 1px solid var(--border-color, #3a3c43);
+  color: var(--color-text-primary, #fff);
+  border-bottom: 1px solid var(--color-border, #3a3c43);
   padding-bottom: 6px;
 }
 
@@ -56,12 +56,12 @@
 .label {
   font-size: 0.85rem;
   font-weight: 500;
-  color: var(--text-primary, #e7ecf3);
+  color: var(--color-text-primary, #e7ecf3);
 }
 
 .help {
   font-size: 0.76rem;
-  color: var(--text-secondary, #9aa6b8);
+  color: var(--color-text-secondary, #9aa6b8);
   line-height: 1.35;
 }
 
@@ -73,26 +73,26 @@
   width: 100%;
   box-sizing: border-box;
   padding: 8px 10px;
-  background: var(--bg-input, #1e1f22);
-  border: 1px solid var(--border-color, #3a3c43);
+  background: var(--color-bg-secondary, #1e1f22);
+  border: 1px solid var(--color-border, #3a3c43);
   border-radius: 5px;
-  color: var(--text-primary, #fff);
+  color: var(--color-text-primary, #fff);
   font-size: 0.85rem;
 }
 
 .input:focus {
   outline: none;
-  border-color: var(--accent-color, #5865f2);
+  border-color: var(--color-accent, #5865f2);
 }
 
 .code {
   width: 100%;
   box-sizing: border-box;
   padding: 10px 12px;
-  background: var(--bg-input, #1e1f22);
-  border: 1px solid var(--border-color, #3a3c43);
+  background: var(--color-bg-secondary, #1e1f22);
+  border: 1px solid var(--color-border, #3a3c43);
   border-radius: 5px;
-  color: var(--text-primary, #fff);
+  color: var(--color-text-primary, #fff);
   font-family: "Fira Code", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.82rem;
   line-height: 1.5;
@@ -102,7 +102,7 @@
 
 .code:focus {
   outline: none;
-  border-color: var(--accent-color, #5865f2);
+  border-color: var(--color-accent, #5865f2);
 }
 
 .checkboxLabel {
@@ -117,44 +117,12 @@
   gap: 10px;
 }
 
-.footer {
-  position: sticky;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 12px;
-  padding-top: 12px;
-  border-top: 1px solid var(--border-color, #3a3c43);
-  background: var(--bg-primary, #141821);
-}
-
 .error {
-  color: #ff8a8a;
+  color: var(--color-danger, #ff8a8a);
   font-size: 0.82rem;
 }
 
 .saved {
-  color: #69d28a;
+  color: var(--color-success, #69d28a);
   font-size: 0.82rem;
-}
-
-.saveBtn {
-  padding: 8px 18px;
-  border: none;
-  border-radius: 6px;
-  background: var(--accent-color, #5865f2);
-  color: #fff;
-  font-size: 0.85rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.saveBtn:hover:not(:disabled) {
-  background: var(--accent-hover, #4752c4);
-}
-
-.saveBtn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }

--- a/crates/mumble-tauri/ui/src/pages/admin/ServerSettingsTab.tsx
+++ b/crates/mumble-tauri/ui/src/pages/admin/ServerSettingsTab.tsx
@@ -9,7 +9,7 @@
  * server applies them at runtime and re-broadcasts the updated snapshot.
  */
 
-import { useEffect, useMemo, useState, type CSSProperties, type ComponentType, type ReactElement } from "react";
+import { useEffect, useMemo, useState, type CSSProperties, type ComponentType, type ReactElement, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { listen } from "@tauri-apps/api/event";
 import * as Flags from "country-flag-icons/react/3x2";
@@ -17,6 +17,12 @@ import type { ServerSetting, ServerSettingsEvent } from "../../types";
 import { COUNTRIES, countryName } from "../../utils/countries";
 import { useServerSettingsStore } from "./serverSettingsStore";
 import styles from "./ServerSettingsTab.module.css";
+import tabStyles from "../../components/elements/TabbedPage.module.css";
+
+export interface ServerSettingsTabProps {
+  /** Hands the tab's Save bar up to `AdminPanel`'s shared pinned footer. */
+  readonly setFooter?: (footer: ReactNode) => void;
+}
 
 interface FieldProps {
   readonly setting: ServerSetting;
@@ -149,7 +155,7 @@ function originalValue(s: ServerSetting): string {
   return s.value ?? "";
 }
 
-export function ServerSettingsTab() {
+export function ServerSettingsTab({ setFooter }: Readonly<ServerSettingsTabProps>) {
   const { t } = useTranslation("settings");
   const snapshot = useServerSettingsStore((s) => s.snapshot);
   const busy = useServerSettingsStore((s) => s.busy);
@@ -210,6 +216,41 @@ export function ServerSettingsTab() {
     }
   };
 
+  const footerNode = useMemo(() => {
+    if (!snapshot) return null;
+    return (
+      <>
+        {error && <span className={styles.error}>{error}</span>}
+        {!error && savedAt > 0 && changed.length === 0 && (
+          <span className={styles.saved}>{t("serverSettings.saved", { defaultValue: "Saved" })}</span>
+        )}
+        <div className={tabStyles.actionBtnGroup}>
+          <button
+            type="button"
+            className={`${tabStyles.actionBtn} ${tabStyles.actionBtnPrimary}`}
+            disabled={busy || changed.length === 0}
+            onClick={() => void onSave()}
+          >
+            {busy
+              ? t("serverSettings.saving", { defaultValue: "Saving…" })
+              : t("serverSettings.save", { defaultValue: "Save changes" })}
+            {changed.length > 0 ? ` (${changed.length})` : ""}
+          </button>
+        </div>
+      </>
+    );
+    // `changed` is derived fresh from `snapshot`+`edits` every render, so
+    // depending on those two (not `changed`/`onSave` themselves) is what
+    // keeps the memoized button's `onClick` from closing over a stale
+    // `edits` snapshot - the same stale-closure trap as useChannelAcl's
+    // `save`, just one level removed via a derived variable.
+  }, [snapshot, edits, error, savedAt, busy, t]);
+
+  useEffect(() => {
+    setFooter?.(footerNode);
+    return () => setFooter?.(null);
+  }, [footerNode, setFooter]);
+
   if (!snapshot) {
     return (
       <div className={styles.empty}>
@@ -253,24 +294,6 @@ export function ServerSettingsTab() {
           </div>
         </section>
       ))}
-
-      <div className={styles.footer}>
-        {error && <span className={styles.error}>{error}</span>}
-        {!error && savedAt > 0 && changed.length === 0 && (
-          <span className={styles.saved}>{t("serverSettings.saved", { defaultValue: "Saved" })}</span>
-        )}
-        <button
-          type="button"
-          className={styles.saveBtn}
-          disabled={busy || changed.length === 0}
-          onClick={() => void onSave()}
-        >
-          {busy
-            ? t("serverSettings.saving", { defaultValue: "Saving…" })
-            : t("serverSettings.save", { defaultValue: "Save changes" })}
-          {changed.length > 0 ? ` (${changed.length})` : ""}
-        </button>
-      </div>
     </div>
   );
 }

--- a/crates/mumble-tauri/ui/src/pages/admin/__tests__/channelAclModel.test.ts
+++ b/crates/mumble-tauri/ui/src/pages/admin/__tests__/channelAclModel.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { buildChannelTree, computeChannelAccess } from "../channelAclModel";
-import type { AclEntry, AclGroup, ChannelEntry } from "../../../types";
+import {
+  buildChannelTree,
+  computeChannelAccess,
+  hasCustomAcl,
+  limitTreeDepth,
+} from "../channelAclModel";
+import type { AclData, AclEntry, AclGroup, ChannelEntry } from "../../../types";
 import { PERM_ENTER, PERM_SPEAK } from "../../../utils/permissions";
 
 function chan(partial: Partial<ChannelEntry> & { id: number }): ChannelEntry {
@@ -77,6 +82,73 @@ describe("buildChannelTree", () => {
       chan({ id: 7, parent_id: 7, name: "Private", detached: true }),
     ]);
     expect(tree.map((n) => n.channel.name)).toEqual(["Private"]);
+  });
+});
+
+describe("limitTreeDepth", () => {
+  const deepTree = () =>
+    buildChannelTree([
+      chan({ id: 0, parent_id: null, name: "Root" }),
+      chan({ id: 1, parent_id: 0, name: "Lobby" }),
+      chan({ id: 2, parent_id: 1, name: "Sub" }),
+      chan({ id: 3, parent_id: 2, name: "SubSub" }),
+    ]);
+
+  it("keeps the root and its direct children, dropping deeper levels", () => {
+    const limited = limitTreeDepth(deepTree(), 1);
+    expect(limited.map((n) => n.channel.name)).toEqual(["Root"]);
+    expect(limited[0].children.map((c) => c.channel.name)).toEqual(["Lobby"]);
+    // "Sub" is depth 2, so it and everything under it is cut.
+    expect(limited[0].children[0].children).toEqual([]);
+  });
+
+  it("leaves only top-level nodes at depth 0", () => {
+    const limited = limitTreeDepth(deepTree(), 0);
+    expect(limited).toHaveLength(1);
+    expect(limited[0].children).toEqual([]);
+  });
+
+  it("returns the tree unchanged when the limit exceeds its depth", () => {
+    expect(limitTreeDepth(deepTree(), 99)).toEqual(deepTree());
+  });
+
+  it("does not mutate the input tree", () => {
+    const tree = deepTree();
+    limitTreeDepth(tree, 0);
+    // The original must still have its full depth: Root > Lobby > Sub > SubSub.
+    expect(tree[0].children[0].children[0].children[0].channel.name).toBe("SubSub");
+  });
+});
+
+describe("hasCustomAcl", () => {
+  function aclData(partial: Partial<AclData>): AclData {
+    return { channel_id: 1, inherit_acls: true, groups: [], acls: [], ...partial };
+  }
+
+  it("is false for a channel that purely inherits", () => {
+    expect(
+      hasCustomAcl(
+        aclData({
+          inherit_acls: true,
+          acls: [acl({ group: "all", grant: PERM_ENTER, inherited: true })],
+          groups: [group({ name: "admin", inherited: true })],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("is true when inheritance is switched off", () => {
+    expect(hasCustomAcl(aclData({ inherit_acls: false }))).toBe(true);
+  });
+
+  it("is true when the channel has a rule of its own", () => {
+    expect(
+      hasCustomAcl(aclData({ acls: [acl({ group: "mods", grant: PERM_ENTER, inherited: false })] })),
+    ).toBe(true);
+  });
+
+  it("is true when the channel defines a group of its own", () => {
+    expect(hasCustomAcl(aclData({ groups: [group({ name: "mods", inherited: false })] }))).toBe(true);
   });
 });
 

--- a/crates/mumble-tauri/ui/src/pages/admin/channelAclModel.ts
+++ b/crates/mumble-tauri/ui/src/pages/admin/channelAclModel.ts
@@ -2,7 +2,7 @@
  * Pure (React-free) model helpers for the Channels / ACL admin view, kept here
  * so they can be unit-tested without rendering.
  */
-import type { AclEntry, AclGroup, ChannelEntry } from "../../types";
+import type { AclData, AclEntry, AclGroup, ChannelEntry } from "../../types";
 import { PERM_ENTER } from "../../utils/permissions";
 
 export interface TreeNode {
@@ -46,6 +46,31 @@ export function buildChannelTree(channels: ChannelEntry[]): TreeNode[] {
   for (const ch of detached) nodes.push({ channel: ch, children: [] });
 
   return nodes;
+}
+
+/**
+ * Truncate every node's descendants beyond `maxDepth` (root nodes are depth
+ * 0). Used by the "Top-level channels only" filter to flatten a deep tree
+ * without having to re-derive it from a filtered channel array (which would
+ * either orphan grandchildren or need the same ancestor-reattachment logic
+ * `filterVisibleChannels` already does for the "hide empty" filter).
+ */
+export function limitTreeDepth(nodes: TreeNode[], maxDepth: number, depth = 0): TreeNode[] {
+  return nodes.map((n) => ({
+    channel: n.channel,
+    children: depth >= maxDepth ? [] : limitTreeDepth(n.children, maxDepth, depth + 1),
+  }));
+}
+
+/** Whether an ACL response indicates the channel doesn't just inherit its
+ *  parent's ACL - i.e. it has its own inheritance override or explicit
+ *  (non-inherited) rules/groups of its own. */
+export function hasCustomAcl(acl: AclData): boolean {
+  return (
+    !acl.inherit_acls ||
+    acl.acls.some((a) => !a.inherited) ||
+    acl.groups.some((g) => !g.inherited)
+  );
 }
 
 export interface ChannelAccess {

--- a/crates/mumble-tauri/ui/src/pages/admin/index.tsx
+++ b/crates/mumble-tauri/ui/src/pages/admin/index.tsx
@@ -109,7 +109,7 @@ export default function AdminPanel() {
       onBack={() => navigate("/chat")}
       footer={tabFooter}
     >
-      <div className={`${styles.content}${tab === "fileServer" ? ` ${styles.contentWide}` : ""}`}>
+      <div className={`${styles.content}${tab === "fileServer" || tab === "acl" ? ` ${styles.contentWide}` : ""}`}>
         {tab === "users" && <RegisteredUsersTab />}
         {tab === "roles" && <RolesListPanel />}
         {tab === "bans" && <BanListTab />}

--- a/crates/mumble-tauri/ui/src/pages/admin/index.tsx
+++ b/crates/mumble-tauri/ui/src/pages/admin/index.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useState } from "react";
+﻿import { useEffect, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { TabbedPage, type TabDef } from "../../components/elements/TabbedPage";
@@ -50,6 +50,15 @@ export default function AdminPanel() {
     return "users";
   })();
   const [tab, setTab] = useState<Tab>(initialTab);
+  // A pinned footer (e.g. Server Settings' / Onboarding's Save bar) is owned
+  // by whichever tab is active - it hands its footer content up here via a
+  // `setFooter` callback prop so it can render in `TabbedPage`'s real
+  // bottom-pinned footer slot instead of scrolling away with the tab's own
+  // content. Cleared on every tab switch so a stale footer never lingers.
+  const [tabFooter, setTabFooter] = useState<ReactNode>(null);
+  useEffect(() => {
+    setTabFooter(null);
+  }, [tab]);
   const customEmotesSupported = useAppStore((s) => s.fileServerCapabilities?.features.custom_emotes ?? false);
   const fileServerEnabled = useAppStore((s) => s.fileServerConfig != null);
   const rootChannelPerms = useAppStore((s) => s.channels.find((c) => c.id === 0)?.permissions ?? 0);
@@ -98,6 +107,7 @@ export default function AdminPanel() {
       activeTab={tab}
       onTabChange={setTab}
       onBack={() => navigate("/chat")}
+      footer={tabFooter}
     >
       <div className={`${styles.content}${tab === "fileServer" ? ` ${styles.contentWide}` : ""}`}>
         {tab === "users" && <RegisteredUsersTab />}
@@ -105,11 +115,11 @@ export default function AdminPanel() {
         {tab === "bans" && <BanListTab />}
         {tab === "acl" && <ChannelAclTab />}
         {tab === "emotes" && <CustomEmotesTab />}
-        {tab === "onboarding" && <OnboardingAdminPanel />}
+        {tab === "onboarding" && <OnboardingAdminPanel setFooter={setTabFooter} />}
         {tab === "serverPlugins" && <ServerPluginsTab />}
         {tab === "marketplace" && <MarketplaceTab />}
         {tab === "fileServer" && <FileServerTab />}
-        {tab === "serverSettings" && <ServerSettingsTab />}
+        {tab === "serverSettings" && <ServerSettingsTab setFooter={setTabFooter} />}
       </div>
     </TabbedPage>
   );

--- a/crates/mumble-tauri/ui/src/pages/admin/useChannelAcl.ts
+++ b/crates/mumble-tauri/ui/src/pages/admin/useChannelAcl.ts
@@ -49,11 +49,17 @@ export function useChannelAcl(channelId: number | null) {
     setDirty(true);
   }, []);
 
-  const save = useCallback(async () => {
-    if (!acl) return;
+  // Accepts an explicit ACL to persist so a caller that just mutated the
+  // snapshot via `setAcl` (update) can save that value immediately, without
+  // waiting for a re-render: `save` is a callback memoized on `acl`, so a
+  // same-handler `setAcl(next); save()` would otherwise still close over the
+  // *previous* render's `acl` and silently persist stale data.
+  const save = useCallback(async (next?: AclData) => {
+    const payload = next ?? acl;
+    if (!payload) return;
     setSaving(true);
     try {
-      await invoke("update_acl", { acl });
+      await invoke("update_acl", { acl: payload });
       setDirty(false);
     } finally {
       setSaving(false);

--- a/crates/mumble-tauri/ui/src/testids.ts
+++ b/crates/mumble-tauri/ui/src/testids.ts
@@ -67,6 +67,25 @@ export const TID = {
   aclDeleteChannel: "acl-delete-channel",
   /** The confirm button shown after clicking {@link aclDeleteChannel}. */
   aclDeleteConfirm: "acl-delete-confirm",
+  /** The "+ Create role" button on the admin "Roles" tab. */
+  rolesCreateButton: "roles-create-button",
+  /** A role row on the admin "Roles" tab list. Carries `data-role-name`. */
+  roleListRow: "role-list-row",
+  /** The "Role {{name}} not found." message body shown on `/admin/role/:name`
+   *  when the requested role isn't in the fetched ACL's group list. Carries
+   *  `data-role-name`. */
+  roleEditorNotFound: "role-editor-not-found",
+  /** The role-name text input on the role editor's "Display" sub-tab. */
+  roleNameInput: "role-name-input",
+  /** The new-role wizard's "Previous" step button (`/admin/roles/new`). */
+  roleWizardPrev: "role-wizard-prev",
+  /** The new-role wizard's "Next" step button. */
+  roleWizardNext: "role-wizard-next",
+  /** The new-role wizard's final-step "Create role" button - only this
+   *  actually persists the draft role to the server. */
+  roleWizardCreate: "role-wizard-create",
+  /** The new-role wizard's "Cancel" button; discards the draft. */
+  roleWizardCancel: "role-wizard-cancel",
   /** The chat header's title (`<h2>`). Carries the channel/peer display name -
    *  e.g. a friend chat shows the peer's name and a self-chat shows your own
    *  name (it is listed as "yourself", not a special "Notepad"). */

--- a/crates/mumble-tauri/ui/src/testids.ts
+++ b/crates/mumble-tauri/ui/src/testids.ts
@@ -63,6 +63,21 @@ export const TID = {
    *  and `data-channel-name`; right-click opens the delete context menu. Detached
    *  (private) channels carry `data-private="true"`. */
   aclChannelItem: "acl-channel-item",
+  /** Checkbox on the "Channels / ACL" tab that hides `__dm:` (friend-chat /
+   *  self-notepad) channels from the tree. */
+  aclHideDmChannels: "acl-hide-dm-channels",
+  /** Checkbox in the ACL tab's filters panel that hides channels with no
+   *  online members. */
+  aclHideEmptyChannels: "acl-hide-empty-channels",
+  /** Checkbox in the ACL tab's filters panel that shows only detached
+   *  (private/meeting-room/DM) channels. */
+  aclPrivateOnly: "acl-private-only",
+  /** Checkbox in the ACL tab's filters panel that flattens the tree to the
+   *  root channel and its direct children. */
+  aclTopLevelOnly: "acl-top-level-only",
+  /** Checkbox in the ACL tab's filters panel that shows only channels with
+   *  a non-inherited ACL override (triggers a bulk `request_acl` fetch). */
+  aclCustomAclOnly: "acl-custom-acl-only",
   /** The "Delete channel" item in the ACL tree's right-click context menu. */
   aclDeleteChannel: "acl-delete-channel",
   /** The confirm button shown after clicking {@link aclDeleteChannel}. */

--- a/crates/qt6ui/Cargo.lock
+++ b/crates/qt6ui/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -526,6 +526,7 @@ dependencies = [
  "cpal",
  "mumble-protocol",
  "tracing",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -1959,14 +1960,36 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1975,7 +1998,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -1986,9 +2022,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -1997,9 +2044,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -2026,9 +2073,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -2036,8 +2099,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2046,7 +2118,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2055,7 +2136,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2082,7 +2163,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2118,11 +2199,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Fixes #104 (`Role new_role not found.`) plus the admin-panel issues found in that area.

Root cause: the app saved too early. Clicking "Create role" sent the server the
role list from before the new role was added - so nothing was created, and the
app then opened an editor for a role that didn't exist: "Role new_role not found."

Closes #104.

## Changes

- **fix(admin)** - `useChannelAcl.save` now takes the ACL to persist explicitly (kills the stale closure). `+ Create role` opens a `/admin/roles/new` wizard: draft stays local across Display → Permissions → Members, persists once on the final step; Cancel/Back discard it. `RoleEditorPage.handleDelete` had the same bug - fixed. Both now return to `/admin?tab=roles` instead of bare `/admin` (which silently defaulted to Users). Editing an existing role unchanged.
- **refactor(admin)** - every admin surface improvised its own action bar at a different size; unified onto a `TabbedPage` `footer` slot with one button style set. Server Settings' bar used `position: sticky`, which only pins once content overflows (floated mid-page on short forms); the shared footer is a real flex row below the scroll area. Also fixes theme vars that **never resolved** (`--text-primary`, `--bg-input`, `--border-color`… → tokens are `--color-*`), so those rules had been ignoring the active theme.
- **fix(audio)** - Settings navigation during a call caused stutter + `dropped 960 oldest samples` bursts. Not a mixer bug: `get_audio_devices`/`get_output_devices` (sync WASAPI/COM) and `list_certificates` (sync fs scan) ran inline on runtime workers, starving the protocol event loop feeding the mixer; the backlog then drained in one pass, evicting a 20 ms Opus frame per packet. Moved to `spawn_blocking` (matches screenshare's existing pattern).
- **i18n(admin)** - `READ_REGISTER` / `SEE_CHANNEL` were in the generated permission list but had no `permissionMeta` entries, so both rows fell back to bare label + generic description. Added for en/de/fr/zh.
- **feat(admin)** - channel filters side panel on Channels / ACL (hide DM, hide empty, private-only, top-level-only, custom-ACL-only) - on a server with friend chats the tree is mostly `__dm:` rooms.
- **test(admin)** - unit tests for the two pure helpers the filters panel added.

## Checklist

- [x] Code compiles without warnings (`cargo clippy --workspace -- -D warnings`) - exit 0; stricter `--all-targets` gate also exit 0
- [x] TypeScript type-checks (`npx tsc --noEmit`) - exit 0; e2e suite `npm run typecheck` also passes
- [x] Frontend tests pass (`npm test`) - 86 files, **1045 passed**, 0 failed
- [x] Rust tests pass (`cargo test --package mumble-protocol --features opus-codec --lib`) - **258 passed**, 0 failed
- [x] New functionality has tests - e2e `admin-create-role.test.ts` covers #104 (asserted the reported `not-found` before the fix); 8 new unit tests for `limitTreeDepth`/`hasCustomAcl`
- [x] Boy Scout Rule applied - removed dead `roleEditor.stepIndicator` key; deleted superseded CSS (`.editorActions`, `.dangerBtn`, `.editorDangerZone`, `.dangerBtnFull`, two local save bars); fixed long-broken theme variables
